### PR TITLE
Fixed createRecord for one-to-none associations

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -328,9 +328,11 @@ DS.FixtureAdapter.reopen({
                   belongsToRecord.constructor,
                   record
                 );
-                Ember.RSVP.resolve(belongsToRecord.get(hasManyName)).then (function(relationship){
-                  relationship.addObject(record);
-                });
+                if (hasManyName) {
+                  Ember.RSVP.resolve(belongsToRecord.get(hasManyName)).then (function(relationship){
+                    relationship.addObject(record);
+                  });
+                }
               }
             });
           });

--- a/tests/fixture_adapter_factory_test.js
+++ b/tests/fixture_adapter_factory_test.js
@@ -149,6 +149,23 @@ asyncTest("#createRecord adds belongsTo association to records it hasMany of", f
   })
 })
 
+asyncTest("#createRecord can work for one-to-none associations", function() {
+  var user = store.makeFixture('user');
+
+  store.find('user', user.id).then(function(user) {
+
+    var smallCompanyJson = {name:'small company', owner: user};
+
+    store.createRecord('small_company', smallCompanyJson).save()
+      .then( function(smallCompany) {
+        return smallCompany.get('owner');
+      }).then( function(owner) {
+        equal(owner.get('id'), user.get('id'));
+        start();
+      });
+  })
+})
+
 asyncTest("#createRecord adds hasMany association to records it hasMany of ", function() {
   var usersJson = store.makeList('user', 3);
 

--- a/tests/support/models/company.js
+++ b/tests/support/models/company.js
@@ -3,3 +3,8 @@ Company = DS.Model.extend({
   profile: DS.belongsTo('profile'),
   users:   DS.hasMany('user', {async: true, inverse: 'company'})
 });
+
+SmallCompany = Company.extend({
+  owner: DS.belongsTo('user', {async: true}),
+  projects: DS.hasMany('project', {async: true})
+});

--- a/tests/support/test_helper.js
+++ b/tests/support/test_helper.js
@@ -18,6 +18,7 @@ TestHelper = Ember.Object.createWithMixins(FactoryGuyTestMixin,{
     container.register("model:user", User);
     container.register("model:profile", Profile);
     container.register("model:company", Company);
+    container.register("model:small_company", SmallCompany);
     container.register("model:property", Property);
     container.register("model:project", Project);
     container.register("store:main", DS.Store.extend({adapter: adapter}));

--- a/tests/test_setup.js
+++ b/tests/test_setup.js
@@ -68,6 +68,11 @@ Company = DS.Model.extend({
   users:   DS.hasMany('user', {async: true, inverse: 'company'})
 });
 
+SmallCompany = Company.extend({
+  owner: DS.belongsTo('user', {async: true}),
+  projects: DS.hasMany('project', {async: true})
+});
+
 Hat = DS.Model.extend({
   type: DS.attr('string'),
   user: DS.belongsTo('user'),

--- a/vendor/assets/javascripts/ember_data_factory_guy.js
+++ b/vendor/assets/javascripts/ember_data_factory_guy.js
@@ -702,9 +702,11 @@ DS.FixtureAdapter.reopen({
                   belongsToRecord.constructor,
                   record
                 );
-                Ember.RSVP.resolve(belongsToRecord.get(hasManyName)).then (function(relationship){
-                  relationship.addObject(record);
-                });
+                if (hasManyName) {
+                  Ember.RSVP.resolve(belongsToRecord.get(hasManyName)).then (function(relationship){
+                    relationship.addObject(record);
+                  });
+                }
               }
             });
           });


### PR DESCRIPTION
Used to die on creating the record. This was due to calling get with undefined key.

This apparently is a non-issue for many-to-none associations since createRecord throws an error if you try to set the up relationship at time of creation.
