### PR TITLE
Fix FixtureAdapter resolve of hasMany relationship on save

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -356,11 +356,13 @@ DS.FixtureAdapter.reopen({
               if (belongsToRecord && belongsToRecord.get('length') > 0) {
                 var hasManyName = store.findRelationshipName(
                   'hasMany',
-                  belongsToRecord.constructor,
+                  belongsToRecord.get('firstObject').constructor,
                   record
                 );
                 belongsToRecord.forEach(function (child){
-                  child.get(hasManyName).addObject(record)
+                  Em.RSVP.resolve(child.get(hasManyName)).then( function(value) {
+                    value.addObjects(record);
+                  });
                 });
               }
             });

--- a/tests/fixture_adapter_factory_test.js
+++ b/tests/fixture_adapter_factory_test.js
@@ -177,10 +177,11 @@ asyncTest("#createRecord adds hasMany association to records it hasMany of ", fu
 
     var propertyJson = {name: 'beach front property'};
 
-    property = store.createRecord('property', propertyJson);
+    var property = store.createRecord('property', propertyJson);
     property.get('owners').then(function (owners) {
       owners.addObjects(users);
-    }).then(function () {
+      return property.save();
+    }).then(function (property) {
       return property.get('owners');
     }).then(function (users) {
       equal(users.get('length'), usersJson.length);


### PR DESCRIPTION
When saved records through FixtureAdapter hasMany relationships were failing.
This was due to using the relationship to determine the opposite side of the hasMany relationship instead of one of the objects.

Updated tests to prove fix.
