### PR TITLE
Test fixes due to ember-data upgrade

### DIFF
--- a/tests/support/models/user.js
+++ b/tests/support/models/user.js
@@ -2,7 +2,7 @@ User = DS.Model.extend({
   name:       DS.attr('string'),
   company:    DS.belongsTo('company', {async: true, inverse: 'users'}),
   properties: DS.hasMany('property', {async: true, inverse: 'owners'}),
-  projects:   DS.hasMany('project'),
+  projects:   DS.hasMany('project', {async: true}),
   hats:       DS.hasMany('hat', {polymorphic: true})
 });
 


### PR DESCRIPTION
For some reason Ember-Data is bringing back synchronous relationships as a
promise.  This was causing the error that the PromiseArray content needs
"The content property of DS.PromiseArray should be set before modifying it".
To bypass this I marked the hasMany side of the relationship as async to get
the tests to pass.  However I think that this might be bug within Ember-data
