### PR TITLE
handleFindQuery json payload must be an array

### DIFF
--- a/src/factory_guy_test_mixin.js
+++ b/src/factory_guy_test_mixin.js
@@ -149,6 +149,7 @@ var FactoryGuyTestMixin = Em.Mixin.create({
       if (Em.typeOf(array[0]) == 'instance') {
         json = array.map(function(user) {return user.toJSON({includeId: true})})
       } else {
+        Ember.assert('When passing a json payload it must be an array - found type:' + Em.typeOf(array), Em.typeOf(array) == 'array')
         json = array;
       }
     }

--- a/tests/factory_guy_test_mixin_test.js
+++ b/tests/factory_guy_test_mixin_test.js
@@ -60,6 +60,10 @@ test("#handleFindQuery second argument should be an array", function(assert) {
   assert.throws(function(){testHelper.handleFindQuery('user', 'name', {})},"second argument not correct type");
 });
 
+test("#handleFindQuery json payload argument should be an array", function(assert) {
+  assert.throws(function(){testHelper.handleFindQuery('user', ['name'], {})},"payload argument is not an array");
+});
+
 asyncTest("#handleFindQuery passing in nothing as last argument returns no results", function() {
   testHelper.handleFindQuery('user', ['name']);
   store.findQuery('user', {name: 'Bob'}).then(function (users) {


### PR DESCRIPTION
I noticed that if you do not pass in an array into handleFindQuery stuff breaks somewhat silently and ember data returns no results. Seems like an obvious one, but I added a small validation so people don't get confused.

```
var car = FactoryGuy.build('car'); //single car { id: 1, name: 'Model S', year: 2014 }
testHelper.handleFindQuery('car', ['year', 'name'], car); 
```

We get into extractArray, and map.call(payload[prop]) executes over an object and it returns an empty array.

```
extractArray: function(store, primaryType, rawPayload) {
...
  var normalizedArray = map.call(payload[prop], function(hash) {
    return typeSerializer.normalize(type, hash, prop);
  }, this);
...
}
```
