### PR TITLE
Delete records created by MockCreateRequest

### DIFF
--- a/src/mock_create_request.js
+++ b/src/mock_create_request.js
@@ -10,6 +10,7 @@ var MockCreateRequest = function(url, store, modelName, options) {
     if (matchArgs) {
       var record = store.createRecord(modelName, matchArgs);
       expectedRequest = record.serialize();
+      record.deleteRecord();
     }
 
     if (succeed) {


### PR DESCRIPTION
When I use `FactoryGuyTestMixin#handleCreate` without a match, it correctly mocks my POST request. When I use a match, it creates a record in my app's store from the match data. Thus my assertion that there should be one record fails, as there are two.

I'm not sure if this is the correct approach, but immediately deleting the record after serialization solves the problem for me. Here's my test case. MODEL is the factory fixture name and helper is a FactoryGuyTestMixin.

```javascript
test('Create', function () {
    expect(2);
    visit('/');
    andThen(function () {
        equal(find('#main table tbody tr').length, 0, 'There should be no todos');
        fillIn('#new-todo', 'Item 1');
        // after this, there is one record
        // helper.handleCreate(MODEL);
        // after this, there are two records
        helper.handleCreate(MODEL, {match: {title: 'Item 1', isCompleted: false}});
        keyEvent('#new-todo', 'keyup', 13);
    });
    andThen(function() {
        equal(find('#main table tbody tr').length, 1, 'There should be one todo');
    });
});
```