### PR TITLE
Use  typeKey for relationship instead of attribute name for build fixture relationship

### DIFF
--- a/src/factory_guy.js
+++ b/src/factory_guy.js
@@ -62,14 +62,15 @@ var FactoryGuy = {
    @param {String} attribute  attribute you want to check
    @returns {Boolean} true if the attribute is a relationship, false if not
    */
-  isAttributeRelationship: function(typeName, attribute) {
+  getAttributeRelationship: function(typeName, attribute) {
     if (!this.store) {
       Ember.debug("FactoryGuy does not have the application's store. Use FactoryGuy.setStore(store) before making any fixtures")
       // The legacy value was true.
       return true;
     }
     var model = this.store.modelFor(typeName);
-    return !!model.typeForRelationship(attribute);
+    var relationship = model.typeForRelationship(attribute);
+    return !!relationship ? relationship : null;
   },
   /**
    Used in model definitions to declare use of a sequence. For example:

--- a/src/model_definition.js
+++ b/src/model_definition.js
@@ -72,8 +72,9 @@ var ModelDefinition = function (model, config) {
         // If it's an object and it's a model association attribute, build the json
         // for the association and replace the attribute with that json
         if (FactoryGuy.getStore()) {
-          if (FactoryGuy.isAttributeRelationship(this.model, attribute)) {
-            fixture[attribute] = FactoryGuy.build(attribute, fixture[attribute]);
+          var relationship = FactoryGuy.getAttributeRelationship(this.model, attribute);
+          if (relationship) {
+            fixture[attribute] = FactoryGuy.build(relationship.typeKey, fixture[attribute]);
           }
         } else {
           // For legacy reasons, if the store is not set in FactoryGuy, keep

--- a/tests/factory_guy_test.js
+++ b/tests/factory_guy_test.js
@@ -195,12 +195,12 @@ test("#buildList creates list of fixtures", function() {
 });
 
 
-test("#isAttributeRelationship", function() {
+test("#getAttributeRelationship", function() {
   FactoryGuy.setStore(store);
   var typeName = 'user'
-  equal(FactoryGuy.isAttributeRelationship(typeName,'company'),true);
-  equal(FactoryGuy.isAttributeRelationship(typeName,'hats'),true);
-  equal(FactoryGuy.isAttributeRelationship(typeName,'name'),false);
+  equal(FactoryGuy.getAttributeRelationship(typeName,'company').typeKey,'company');
+  equal(FactoryGuy.getAttributeRelationship(typeName,'hats').typeKey,'hat');
+  equal(FactoryGuy.getAttributeRelationship(typeName,'name'),null);
 });
 
 


### PR DESCRIPTION
When building a fixture with relationships, FactoryGuy.build() is called with the relationship attribute name rather than that attributes model type.

It currently works only when relationship attributes have the same name as the model type they're related to.

So this works:
User = DS.Model.extend({
    company:     DS.belongsTo('company',)
});

But this doesn't:
User = DS.Model.extend({
    default_company:     DS.belongsTo('company',)
});

Build tries to find a factory named 'default_company' rather than the 'company' factory.