### PR TITLE
Get this add-on working when prototype extensions are disabled in Ember

### DIFF
--- a/addon/factory-guy-test-helper.js
+++ b/addon/factory-guy-test-helper.js
@@ -91,7 +91,7 @@ var FactoryGuyTestHelper = Ember.Object.create({
   */
   mapFindAll: function(modelName, json) {
     var responseJson = {};
-    responseJson[modelName.pluralize()] = json;
+    responseJson[Ember.String.pluralize(modelName)] = json;
     return responseJson;
   },
   /**
@@ -105,7 +105,7 @@ var FactoryGuyTestHelper = Ember.Object.create({
   */
   mapFind:function(modelName, json){
     var responseJson = {};
-    responseJson[modelName.pluralize()] = json;
+    responseJson[Ember.String.pluralize(modelName)] = json;
     return responseJson;
   },
   /**

--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -354,7 +354,7 @@ var FactoryGuy = {
       if (fixture.type) {
         // assuming its polymorphic if there is a type attribute
         // is this too bold an assumption?
-        modelName = fixture.type.underscore();
+        modelName = Ember.String.underscore(fixture.type);
         modelType = store.modelFor(modelName);
       }
       model = store.push(modelName, fixture);

--- a/tests/dummy/app/components/translate.js
+++ b/tests/dummy/app/components/translate.js
@@ -8,9 +8,9 @@ var TranslateComponent = Ember.Component.extend({
   layout: layout,
   classNames: ['translate'],
 
-  translation: function() {
+  translation: Ember.computed('original', function() {
     return this.get('original') + ' dude';
-  }.property('original')
+  })
 
 });
 

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import DS from 'ember-data';
 
 export default DS.Model.extend({
@@ -8,7 +9,7 @@ export default DS.Model.extend({
   projects:   DS.hasMany('project', {embedded: 'always'}),
   hats:       DS.hasMany('hat', {polymorphic: true}),
 
-  funnyName: function() {
+  funnyName: Ember.computed("name", function() {
     return "funny " + this.get('name');
-  }.property('name')
+  })
 });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -10,7 +10,10 @@ module.exports = function(environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
-      }
+      },
+
+      // http://emberjs.com/guides/configuring-ember/disabling-prototype-extensions/
+      EXTEND_PROTOTYPES: false
     },
 
     APP: {

--- a/tests/unit/rest-adapter-factory-test.js
+++ b/tests/unit/rest-adapter-factory-test.js
@@ -325,6 +325,7 @@ module('FactoryGuy with DS.RESTAdapter #makeList', {
 
 test("creates list of DS.Model instances", function() {
   var users = FactoryGuy.makeList('user', 2);
+  Ember.A(users);
   equal(users.get('length'), 2);
   ok(users[0] instanceof DS.Model === true);
 
@@ -335,6 +336,7 @@ test("creates list of DS.Model instances", function() {
 
 test("handles accept traits", function() {
   var users = FactoryGuy.makeList('user', 2, 'with_hats');
+  Ember.A(users);
   equal(users.get('length'), 2);
   equal(users[0].get('hats.length') === 2, true);
 });


### PR DESCRIPTION
The app I'm working on requires that I [disable prototype extensions](http://guides.emberjs.com/v1.10.0/configuring-ember/disabling-prototype-extensions/). Factory Guy wasn't coded to accommodate that.

This commit at least gets the tests passing after I changed `tests/dummy/config/environment.js` so that `EXTEND_PROTOTYPES` is `false`. I'm not sure that it fixes all of the issues that may be introduced, but at least it's letting me test my app now.

The [new default](https://github.com/ember-cli/ember-cli/issues/3443) for developing add-ons is to have prototype extensions turned off, so this brings Factory Guy up to code with that standard.