### PR TITLE
[WIP] Add andFail() method to handleFind()

### DIFF
--- a/addon/factory-guy-test-helper.js
+++ b/addon/factory-guy-test-helper.js
@@ -4,6 +4,7 @@ import $ from 'jquery';
 import FactoryGuy from './factory-guy';
 import MockUpdateRequest from './mock-update-request';
 import MockCreateRequest from './mock-create-request';
+import MockGetRequest from './mock-get-request';
 
 var FactoryGuyTestHelper = Ember.Object.create({
 
@@ -161,7 +162,7 @@ var FactoryGuyTestHelper = Ember.Object.create({
 
      @param {String} name  name of the fixture ( or model ) to find
      @param {String} trait  optional traits (one or more)
-     @param {Object} opts  optional fixture options (including id)
+     @param {Object} options  optional fixture options (including id)
    */
   handleFind: function () {
     var args = Array.prototype.slice.call(arguments);
@@ -178,10 +179,8 @@ var FactoryGuyTestHelper = Ember.Object.create({
       modelName = FactoryGuy.lookupModelForFixtureName(name);
     }
 
-    var json = record.toJSON({includeId: true});
-    var responseJson = this.mapFind(modelName, json);
     var url = this.buildURL(modelName, record.id);
-    this.stubEndpointForHttpRequest(url, responseJson);
+    return new MockGetRequest(url, modelName, record, this.mapFind);
   },
   handleFindOne: function() { this.handleFind.apply(this, arguments); },
   /**

--- a/addon/mock-get-request.js
+++ b/addon/mock-get-request.js
@@ -1,0 +1,51 @@
+import $ from 'jquery';
+
+var MockGetRequest = function (url, modelName, record, mapFind) {
+  var status = 200;
+  var succeed = true;
+  var response = null;
+
+  this.andSucceed = function (options) {
+    succeed = true;
+    status = options && options.status || 200;
+
+    return this;
+  };
+
+  this.andFail = function (options) {
+    console.log('INFO: andFail is called');
+    options = options || {};
+    succeed = false;
+    status = options.status || 500;
+    response = options.response || {};
+
+    return this;
+  };
+
+  this.handler = function () {
+
+    if (succeed === false) {
+      this.status = status;
+      this.responseText = response;
+    } else {
+      this.status = status;
+      this.responseText = mapFind(
+        modelName,
+        record.toJSON({
+          includeId: true
+        })
+      );
+    }
+  };
+
+  var requestConfig = {
+    url: url,
+    dataType: 'json',
+    type: 'GET',
+    response: this.handler
+  };
+
+  $.mockjax(requestConfig);
+};
+
+export default MockGetRequest;

--- a/tests/unit/factory-guy-test-helper-test.js
+++ b/tests/unit/factory-guy-test-helper-test.js
@@ -3,6 +3,7 @@ import FactoryGuy, { make, makeList } from 'ember-data-factory-guy';
 import TestHelper from 'ember-data-factory-guy/factory-guy-test-helper';
 import MissingSequenceError from 'ember-data-factory-guy/missing-sequence-error';
 
+import $ from 'jquery';
 import User from 'dummy/models/user';
 import BigHat from 'dummy/models/big-hat';
 import SmallHat from 'dummy/models/small-hat';
@@ -274,6 +275,24 @@ test("#handleFind with traits and arguments", function (assert) {
   store.find('profile', 1).then(function (profile) {
     ok(profile.get('description') === description);
     done();
+  });
+});
+
+test("#handleFind failure with andFail method", function (assert) {
+  Ember.run(function () {
+    var done = assert.async();
+    TestHelper.handleFind('profile', 1).andFail();
+
+    store.find('profile', 1).then(
+      function (response) {
+        ok(false);
+        done();
+      },
+      function (error) {
+        ok(true);
+        done();
+      }
+    );
   });
 });
 


### PR DESCRIPTION
This pullrequest implements issue #84 it adds the same `andFail()` method chaining functionality that is already implemented for `PUT` and `DELETE` requests to the `handleFind()` test-helper.

TODO:

- [ ] fix specs
- [ ] update comments to reflect new method