### PR TITLE
update store:main references to use store:application as store:main is now deprecated

### DIFF
--- a/addon/factory-guy-test-helper.js
+++ b/addon/factory-guy-test-helper.js
@@ -43,7 +43,7 @@ var FactoryGuyTestHelper = Ember.Object.create({
     return this.getStore().find(type, id);
   },
   getStore: function () {
-    return this.get('container').lookup('store:main');
+    return this.get('container').lookup('store:application');
   },
   /**
    Using mockjax to stub an http request.

--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -50,7 +50,7 @@ var FactoryGuy = {
    */
   setup: function (app) {
     Ember.assert("FactoryGuy#setup needs a valid application instance.You passed in [" + app + "]", app instanceof Ember.Application);
-    this.setStore(app.__container__.lookup('store:main'));
+    this.setStore(app.__container__.lookup('store:application'));
   },
   /**
    Setting the store so FactoryGuy can do some model introspection.

--- a/app/initializers/ember-data-factory-guy.js
+++ b/app/initializers/ember-data-factory-guy.js
@@ -8,7 +8,7 @@ export default {
   after: 'store',
 
   initialize: function(container, application) {
-    FactoryGuy.setStore(container.lookup('store:main'));
+    FactoryGuy.setStore(container.lookup('store:application'));
     FactoryGuyTestHelper.set('container', container);
     FactoryGuy.resetDefinitions();
 

--- a/vendor/assets/javascripts/ember_data_factory_guy.js
+++ b/vendor/assets/javascripts/ember_data_factory_guy.js
@@ -939,7 +939,7 @@ var FactoryGuyTestMixin = Em.Mixin.create({
     return FactoryGuy.make.apply(FactoryGuy, arguments);
   },
   getStore: function () {
-    return this.get('container').lookup('store:main');
+    return this.get('container').lookup('store:application');
   },
   /**
    Using mockjax to stub an http request.


### PR DESCRIPTION
fixs

```
DEPRECATION: You tried to look up 'store:main', but this has been deprecated in favor of 'store:application'.
        at ember$data$lib$system$container$proxy$$ContainerProxy.registerDeprecation.preLookupCallback (http://localhost:4200/provider/assets/vendor.js:125945:15)
        at Object.ember$data$lib$system$container$proxy$$ContainerProxy.aliasedFactory.create (http://localhost:4200/provider/assets/vendor.js:125929:13)
        at instantiate (http://localhost:4200/provider/assets/vendor.js:17010:26)
        at lookup (http://localhost:4200/provider/assets/vendor.js:16849:19)
        at Object.Container.lookup (http://localhost:4200/provider/assets/vendor.js:16494:16)
        at exports.default.initialize (http://localhost:4200/provider/assets/inbox-dashboard.js:7014:48)
        at http://localhost:4200/provider/assets/vendor.js:18175:11
        at visit (http://localhost:4200/provider/assets/vendor.js:17098:7)
        at DAG.topsort (http://localhost:4200/provider/assets/vendor.js:17210:11)
```

https://github.com/emberjs/data/pull/3136