### PR TITLE
Work without prototype extensions

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -470,6 +470,7 @@ var FactoryGuy = function () {
     Add the model to included array unless it's already there.
    */
   var addToIncluded = function (included, data) {
+    included = Ember.A(included);
     var found = included.find(function(model) {
       return model.id === data.id && model.type === data.type;
     });


### PR DESCRIPTION
Ember addons are expected to work without prototype extensions, because an application may or may not have prototype extensions enabled, and addons need to work with any application. (Plus, my application has them disabled, and Factory Guy broke.)