### PR TITLE
Ember 2.0 fixes

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import ModelDefinition from './model-definition';
 import FixtureBuilderFactory from './fixture-builder-factory';
+import ActiveModelAdapter from 'active-model-adapter';
 
 var FactoryGuy = function () {
   var modelDefinitions = {};
@@ -62,7 +63,7 @@ var FactoryGuy = function () {
     var adapter = store.adapterFor('application');
     var useJSONAPI = (adapter instanceof DS.JSONAPIAdapter);
     var isREST = (adapter instanceof DS.RESTAdapter) && !useJSONAPI;
-    var isAMS = (adapter instanceof DS.ActiveModelAdapter);
+    var isAMS = DS.ActiveModelAdapter && (adapter instanceof DS.ActiveModelAdapter) || (adapter instanceof ActiveModelAdapter);
     return !isAMS && !isREST;
   };
   /**

--- a/app/initializers/ember-data-factory-guy.js
+++ b/app/initializers/ember-data-factory-guy.js
@@ -10,7 +10,7 @@ export default {
   initialize: function(registry, application) {
     // ember 1.12+ no longer passing in container and application, but registry and application
     // But make sure you are using ember-cli/ember-load-initializers#0.1.4
-    var container = (registry._defaultContainer) ? registry._defaultContainer : registry;
+    var container = registry._defaultContainer || application.__container__ || registry;
     FactoryGuy.setStore(container.lookup('service:store'));
     FactoryGuyTestHelper.set('container', container);
     FactoryGuy.resetDefinitions();

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "active-model-adapter": "^1.13.5",
     "broccoli-asset-rev": "^2.0.2",
     "ember-cli": "1.13.1",
     "ember-cli-app-version": "0.3.3",


### PR DESCRIPTION
* Fix error due to removal of DS.ActiveModelAdapter
* Fix error due to container.lookup being undefined in initializer