### PR TITLE
Allow usage of applications serializer to transform attributes

### DIFF
--- a/addon/jsonapi-attribute-transformer.js
+++ b/addon/jsonapi-attribute-transformer.js
@@ -62,7 +62,7 @@ var JSONAPIAttributeTransformer = function (store) {
     var transformFunction = serializer.keyForAttribute || Ember.String.dasherize;
     for (var key in object) {
       var value = object[key];
-      var newKey = transformFunction.call(key);
+      var newKey = transformFunction(key);
       delete object[key];
       object[newKey] = value;
     }
@@ -84,8 +84,20 @@ var JSONAPIAttributeTransformer = function (store) {
         transformAttributes(modelName, data);
       }
     }
-    transformObjectKeys(modelName, fixture.relationships);
+    transformRelationshipObjectKeys(modelName, fixture.relationships);
   };
+
+  var transformRelationshipObjectKeys = function(modelName, object) {
+    var serializer = store.serializerFor(modelName);
+    var transformFunction = serializer.keyForRelationship || Ember.String.dasherize;
+    for (var key in object) {
+      var value = object[key];
+      var newKey = transformFunction(key);
+      delete object[key];
+      object[newKey] = value;
+    }
+  };
+
 };
 
 export default JSONAPIAttributeTransformer;


### PR DESCRIPTION
This should resolve issue #116, but it's just an initial set of commits.

However, if I'm going in the completely wrong direction, anyone is free to point it out.

At this point, It seems the fix works with our project, but it's not covered with tests yet. I haven't quite figured out the tests yet and I don't want to upset the established conventions.

The way I see it, I should

* Have two models which use two serializers, both of which use something other than the default dasherize approach for serializing attribute and relationship keys. Underscore is probably easiest.
* Check that making/building fixtures using those models and their factories gives me models with proper keys and relationships present.

Anything I may have missed?

An unfortunate consequence of the approach I used is that I need to pass in the model name all the way from the top to the bottom (to transformObjectKeys). If anyone has a better idea there, please let me know. In the meantime, I'll keep looking.