### PR TITLE
Attribute typing

### DIFF
--- a/addon/rest-fixture-converter.js
+++ b/addon/rest-fixture-converter.js
@@ -78,10 +78,9 @@ var RestFixtureConverter = function (store) {
     var transformFunction = getTransformFunction(modelName, 'Attribute');
     store.modelFor(modelName).eachAttribute(function (attribute) {
       var attributeKey = transformFunction(attribute);
-      //console.log('attribute', attribute, attributeKey, fixture.hasOwnProperty(attribute), fixture.hasOwnProperty(attributeKey))
-      if (fixture[attribute]) {
+      if (fixture.hasOwnProperty(attribute)) {
         attributes[attributeKey] = fixture[attribute];
-      } else if (fixture[attributeKey]) {
+      } else if (fixture.hasOwnProperty(attributeKey)) {
         attributes[attributeKey] = fixture[attributeKey];
       }
     });

--- a/tests/dummy/app/models/profile.js
+++ b/tests/dummy/app/models/profile.js
@@ -5,6 +5,7 @@ export default DS.Model.extend({
   description:            DS.attr('string'),
   camelCaseDescription:   DS.attr('string'),
   snake_case_description: DS.attr('string'),
+  aBooleanField:          DS.attr('boolean'),
   superHero:              DS.belongsTo('super-hero', {async: false}),
   company:                DS.belongsTo('company', {async: false}),
   group:                  DS.belongsTo('group', {async: false, polymorphic: true})

--- a/tests/dummy/app/tests/factories/profile.js
+++ b/tests/dummy/app/tests/factories/profile.js
@@ -5,7 +5,7 @@ FactoryGuy.define('profile', {
     description: 'Text goes here',
     camelCaseDescription: 'textGoesHere',
     snake_case_description: 'text_goes_here',
-    aBooleanField: true
+    aBooleanField: false
   },
   traits: {
     goofy_description: {

--- a/tests/dummy/app/tests/factories/profile.js
+++ b/tests/dummy/app/tests/factories/profile.js
@@ -4,7 +4,8 @@ FactoryGuy.define('profile', {
   default: {
     description: 'Text goes here',
     camelCaseDescription: 'textGoesHere',
-    snake_case_description: 'text_goes_here'
+    snake_case_description: 'text_goes_here',
+    aBooleanField: true
   },
   traits: {
     goofy_description: {

--- a/tests/unit/active-model-adapter-test.js
+++ b/tests/unit/active-model-adapter-test.js
@@ -43,6 +43,7 @@ test("sideloads belongsTo records", function () {
     profile: {
       id: 1,
       description: 'Text goes here',
+      'a_boolean_field': true,
       'camel_case_description': 'textGoesHere',
       'snake_case_description': 'text_goes_here',
       'super_hero_id': 1,
@@ -99,6 +100,7 @@ test("using custom serialize keys function for transforming attributes and relat
       description: 'Text goes here',
       'camel-case-description': 'textGoesHere',
       'snake-case-description': 'text_goes_here',
+      'a-boolean-field': true,
       'super-hero': 1,
     },
     'super-heros': [

--- a/tests/unit/active-model-adapter-test.js
+++ b/tests/unit/active-model-adapter-test.js
@@ -43,7 +43,7 @@ test("sideloads belongsTo records", function () {
     profile: {
       id: 1,
       description: 'Text goes here',
-      'a_boolean_field': true,
+      'a_boolean_field': false,
       'camel_case_description': 'textGoesHere',
       'snake_case_description': 'text_goes_here',
       'super_hero_id': 1,
@@ -100,7 +100,7 @@ test("using custom serialize keys function for transforming attributes and relat
       description: 'Text goes here',
       'camel-case-description': 'textGoesHere',
       'snake-case-description': 'text_goes_here',
-      'a-boolean-field': true,
+      'a-boolean-field': false,
       'super-hero': 1,
     },
     'super-heros': [

--- a/tests/unit/jsonapi-adapter-test.js
+++ b/tests/unit/jsonapi-adapter-test.js
@@ -319,7 +319,8 @@ test("when no custom serialize keys functions exist, dasherizes attributes and r
         attributes: {
           description: 'Text goes here',
           'camel-case-description': 'textGoesHere',
-          'snake-case-description': 'text_goes_here'
+          'snake-case-description': 'text_goes_here',
+          'a-boolean-field': true
         },
         relationships: {
           'super-hero': {
@@ -357,7 +358,8 @@ test("using custom serialize keys function for transforming attributes and relat
         attributes: {
           description: 'Text goes here',
           'camel_case_description': 'textGoesHere',
-          'snake_case_description': 'text_goes_here'
+          'snake_case_description': 'text_goes_here',
+          'a_boolean_field': true
         },
         relationships: {
           'super_hero': {
@@ -455,5 +457,3 @@ test("with (nested json fixture) belongsTo has a hasMany association which has a
   deepEqual(projectJson.included, expectedData.included);
 
 });
-
-

--- a/tests/unit/jsonapi-adapter-test.js
+++ b/tests/unit/jsonapi-adapter-test.js
@@ -320,7 +320,7 @@ test("when no custom serialize keys functions exist, dasherizes attributes and r
           description: 'Text goes here',
           'camel-case-description': 'textGoesHere',
           'snake-case-description': 'text_goes_here',
-          'a-boolean-field': true
+          'a-boolean-field': false
         },
         relationships: {
           'super-hero': {
@@ -359,7 +359,7 @@ test("using custom serialize keys function for transforming attributes and relat
           description: 'Text goes here',
           'camel_case_description': 'textGoesHere',
           'snake_case_description': 'text_goes_here',
-          'a_boolean_field': true
+          'a_boolean_field': false
         },
         relationships: {
           'super_hero': {

--- a/tests/unit/rest-adapter-test.js
+++ b/tests/unit/rest-adapter-test.js
@@ -23,6 +23,7 @@ test("sideloads belongsTo records", function (assert) {
       description: 'Text goes here',
       camelCaseDescription: 'textGoesHere',
       snake_case_description: 'text_goes_here',
+      aBooleanField: true,
       superHero: 1,
     },
     'super-heros': [
@@ -74,6 +75,7 @@ test("sideloads belongsTo records", function (assert) {
         description: 'Text goes here',
         camelCaseDescription: 'textGoesHere',
         snake_case_description: 'text_goes_here',
+        aBooleanField: true,
         superHero: 1,
       },
       {
@@ -81,6 +83,7 @@ test("sideloads belongsTo records", function (assert) {
         description: 'Text goes here',
         camelCaseDescription: 'textGoesHere',
         snake_case_description: 'text_goes_here',
+        aBooleanField: true,
         superHero: 2,
       }
     ],

--- a/tests/unit/rest-adapter-test.js
+++ b/tests/unit/rest-adapter-test.js
@@ -23,7 +23,7 @@ test("sideloads belongsTo records", function (assert) {
       description: 'Text goes here',
       camelCaseDescription: 'textGoesHere',
       snake_case_description: 'text_goes_here',
-      aBooleanField: true,
+      aBooleanField: false,
       superHero: 1,
     },
     'super-heros': [
@@ -75,7 +75,7 @@ test("sideloads belongsTo records", function (assert) {
         description: 'Text goes here',
         camelCaseDescription: 'textGoesHere',
         snake_case_description: 'text_goes_here',
-        aBooleanField: true,
+        aBooleanField: false,
         superHero: 1,
       },
       {
@@ -83,7 +83,7 @@ test("sideloads belongsTo records", function (assert) {
         description: 'Text goes here',
         camelCaseDescription: 'textGoesHere',
         snake_case_description: 'text_goes_here',
-        aBooleanField: true,
+        aBooleanField: false,
         superHero: 2,
       }
     ],


### PR DESCRIPTION
@danielspaniel I encountered a potential bug in factory guy - If a definition or a build (with custom attribute) contains an attribute with a default value that is `false`, that attribute does not get carried over into the store or get converted properly. 

```javascript
 // addon/rest-fixture-converter.js
  var extractAttributes = function (modelName, fixture) {
    var attributes = {};
    var transformFunction = getTransformFunction(modelName, 'Attribute');
    store.modelFor(modelName).eachAttribute(function (attribute) {
      var attributeKey = transformFunction(attribute);
      //console.log('attribute', attribute, attributeKey, fixture.hasOwnProperty(attribute), fixture.hasOwnProperty(attributeKey))
      if (fixture[attribute]) {
        attributes[attributeKey] = fixture[attribute];
      } else if (fixture[attributeKey]) {
        attributes[attributeKey] = fixture[attributeKey];
      }
    });
    return attributes;
  };
```

Whichever key is used, `attribute` or `attributeKey`, a value that is `false` will not copy with the conditionals set above. This only seems to affect the REST adapter. In order to make the tests pass, I had to slightly change some of the tests to include the `aBooleanField`. Please let me know if the changes would work or if there's something that I am missing.