### PR TITLE
Fix jquery-mockjax bower package addition to Project

### DIFF
--- a/blueprints/ember-data-factory-guy/index.js
+++ b/blueprints/ember-data-factory-guy/index.js
@@ -2,10 +2,8 @@ module.exports = {
   // Hack for previous versions of Ember CLI
   normalizeEntityName: function() {},
 
-  afterInstall: function(options) {
+  afterInstall: function() {
     return this.addBowerPackageToProject('jquery-mockjax', '2.0.1');
-  },
-
-  initialize: function(container, application) {
   }
+
 };

--- a/index.js
+++ b/index.js
@@ -3,10 +3,6 @@ var path = require('path');
 module.exports = {
   name: 'ember-data-factory-guy',
 
-  blueprintsPath: function() {
-    return path.join(__dirname, 'blueprints');
-  },
-
   included: function(app) {
     this._super.included(app);
     // need to load mockjax in development and test environment since ember tests


### PR DESCRIPTION
I am using ember-cli@1.13.8, `jquery-mockjax` didn't added automatically to my bower.json after installing ember-data-factory-guy, I had to remove initialize function from `blueprints/ember-data-factory-guy/index.js` to make it work.

I also removed `blueprintsPath` from `index.js` because this is only required when `blueprints` is not present in root directory. http://www.ember-cli.com/extending/#blueprint-conventions