### PR TITLE
Don't assume application adapter.

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -8,6 +8,7 @@ var FactoryGuy = function () {
   var store = null;
   var fixtureBuilderFactory = null;
   var fixtureBuilder = null;
+  var fixtureBuilders = {};
   var self = this;
   /**
    ```javascript
@@ -78,6 +79,15 @@ var FactoryGuy = function () {
   };
   this.getFixtureBuilder = function () {
     return fixtureBuilder;
+  };
+  this.getFixtureBuilderFor = function (modelName) {
+    if (!fixtureBuilders[modelName]) {
+      var factory = new FixtureBuilderFactory(store, modelName);
+
+      fixtureBuilders[modelName]  = factory.getFixtureBuilder();
+    }
+
+    return fixtureBuilders[modelName];
   };
   /**
    Used in model definitions to declare use of a sequence. For example:
@@ -255,7 +265,7 @@ var FactoryGuy = function () {
     var fixture = this.buildRaw.apply(this, arguments);
     var modelName = lookupModelForFixtureName(args.name);
 
-    return fixtureBuilder.convertForBuild(modelName, fixture);
+    return this.getFixtureBuilderFor(modelName).convertForBuild(modelName, fixture);
   };
 
   this.buildRaw = function () {
@@ -290,7 +300,7 @@ var FactoryGuy = function () {
     var list = this.buildRawList.apply(this, arguments);
 
     var modelName = lookupModelForFixtureName(name);
-    return fixtureBuilder.convertForBuild(modelName, list);
+    return this.getFixtureBuilderFor(modelName).convertForBuild(modelName, list);
   };
 
   this.buildRawList = function () {
@@ -330,7 +340,7 @@ var FactoryGuy = function () {
 
     var modelName = lookupModelForFixtureName(args.name);
     var fixture = this.buildRaw.apply(this, arguments);
-    var data = fixtureBuilder.convertForMake(modelName, fixture);
+    var data = this.getFixtureBuilderFor(modelName).convertForMake(modelName, fixture);
 
     var model = makeModel(modelName, data);
 

--- a/addon/fixture-builder-factory.js
+++ b/addon/fixture-builder-factory.js
@@ -2,8 +2,9 @@ import DS from 'ember-data';
 import JSONAPIFixtureBuilder from './jsonapi-fixture-builder';
 import RESTFixtureBuilder from './rest-fixture-builder';
 
-var FixtureBuilderFactory = function (store) {
-  var adapter = store.adapterFor('application');
+var FixtureBuilderFactory = function (store, adapterFor) {
+
+  var adapter = store.adapterFor(adapterFor || 'application');
   /*
    Using json api?
    TODO: extract this to utility class


### PR DESCRIPTION
This is not ready and is meant to show an issue which happens when using custom adapter.

If you are using a custom adapter/serializer for some models, the
generated output for build won't be correct since it always assume the
application adapter.

In my example, my application adapter if using "active-model" but I'm
starting to migrate some model to JSONAPI which use a different adapter.

A better approach could be to have a "cache" of fixtureBuilders which is resolve the correct adapter in flight.