### PR TITLE
Removes legacy getStore method

### DIFF
--- a/addon/factory-guy-test-helper.js
+++ b/addon/factory-guy-test-helper.js
@@ -25,9 +25,7 @@ var FactoryGuyTestHelper = Ember.Object.create({
     var controller = this.controllerFor(controller_name);
     controller.set(property, value);
   },
-  getStore: function () {
-    return FactoryGuy.get('store');
-  },
+
   /**
    Using mockjax to stub an http request.
 
@@ -61,7 +59,7 @@ var FactoryGuyTestHelper = Ember.Object.create({
    @return {String} url
    */
   buildURL: function (modelName, id) {
-    var adapter = this.getStore().adapterFor(modelName);
+    var adapter = FactoryGuy.get('store').adapterFor(modelName);
     return adapter.buildURL(modelName, id);
   },
   /**
@@ -282,7 +280,7 @@ var FactoryGuyTestHelper = Ember.Object.create({
   handleCreate: function (modelName, options) {
     var url = this.buildURL(modelName);
     var opts = options === undefined ? {} : options;
-    
+
     return new MockCreateRequest(url, modelName, opts);
   },
 
@@ -316,7 +314,7 @@ var FactoryGuyTestHelper = Ember.Object.create({
     }
 
     var model, type, id;
-    var store = this.getStore();
+    var store = FactoryGuy.get('store');
 
     if (args[0] instanceof DS.Model) {
       model = args[0];

--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -138,14 +138,6 @@ var FactoryGuy =  Ember.Object.extend({
 
   /**
    The method has been kept for backward compatibility
-   Use `instance.get('store')` instead.
-   */
-  getStore() {
-    return this.get('store');
-  },
-
-  /**
-   The method has been kept for backward compatibility
    Use `instance.get('fixtureBuilder')` instead.
    */
   getFixtureBuilder() {


### PR DESCRIPTION
Continuing the work initiated in 7cf90b1c3c7a130298675386fe13edd50477ed78, this PR removes the last occurrences of `FactoryGuy.getStore()`.

