### PR TITLE
handleFindAll() and buildList() can make diverse models

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,19 @@ will look like this:
   - For dealing with finding all records of a particular type
   - Sample acceptance tests using handleFindAll: [(users-view-test.js)](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/acceptance/users-view-test.js) [(users-delete-test.js)](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/acceptance/users-delete-test.js)
 
+Usage:
+
+```javascript
+  // The mock API can return several different models
+  TestHelper.handleFindAll('user', {name: 'Bob'}, ['admin', {name: 'Jane'}]); // findAll('user') will return a user named Bob and an admin user named Jane
+
+  // Or it can return multiple of the same model (other than ids and sequences)
+  TestHelper.handleFindAll('user', 2);
+  TestHelper.handleFindAll('user', 2, 'admin'); // You can specify traits
+  TestHelper.handleFindAll('user', 2, {name: 'Bob'}); // Or attributes
+  TestHelper.handleFindAll('user', 2, 'admin', {name: 'Bob'}); // Or both
+```
+
 If when visiting a route, some part of your application ( like router, or
 controller action ) is going to make a call to the store for all records of
 a particular type:
@@ -781,6 +794,8 @@ will look like this:
     ok(users.length === 2);
   });
 ```
+
+
 
 If you would like to interact with the records created by handleFindAll (for example to update, delete, or find in the store)
 you must wait on the request for those records to resolve before they will be loaded in the store:

--- a/tests/unit/factory-guy-test.js
+++ b/tests/unit/factory-guy-test.js
@@ -703,6 +703,12 @@ test("using traits and custom attributes", function () {
   deepEqual(projectList, expected);
 });
 
+test("using diverse attributes", function() {
+  var projectList = FactoryGuy.buildRawList('project', 'big', {title: 'Really Big'}, ['with_dude', {title: 'I have a dude'}]);
+  var expected = [{id: 1, title: 'Big Project'}, {id: 2, title: 'Really Big'}, {id: 3, title: 'I have a dude', user: {id: 1, name: 'Dude'}}];
+  deepEqual(projectList, expected);
+});
+
 module('FactoryGuy and JSONAPI', inlineSetup(App, '-json-api'));
 test('it knows how to update with JSON-API', function (assert) {
   const method = FactoryGuy.get('updateHTTPMethod');

--- a/tests/unit/shared-factory-guy-test-helper-tests.js
+++ b/tests/unit/shared-factory-guy-test-helper-tests.js
@@ -266,6 +266,24 @@ SharedBehavior.handleFindAllTests = function () {
     });
   });
 
+  test("with diverse models", function (assert) {
+    Ember.run(function () {
+      var done = assert.async();
+      TestHelper.handleFindAll('profile', 'goofy_description', {description: 'foo'}, ['goofy_description', {aBooleanField: true}]);
+
+      FactoryGuy.get('store').findAll('profile').then(function (profiles) {
+        ok(profiles.get('length') === 3);
+        ok(profiles.objectAt(0).get('description') === 'goofy');
+        ok(profiles.objectAt(0).get('aBooleanField') === false);
+        ok(profiles.objectAt(1).get('description') === 'foo');
+        ok(profiles.objectAt(1).get('aBooleanField') === false);
+        ok(profiles.objectAt(2).get('description') === 'goofy');
+        ok(profiles.objectAt(2).get('aBooleanField') === true);
+        done();
+      });
+    });
+  });
+
 
 };
 

--- a/tests/unit/shared-factory-guy-test-helper-tests.js
+++ b/tests/unit/shared-factory-guy-test-helper-tests.js
@@ -889,14 +889,14 @@ SharedBehavior.handleCreateTests = function () {
   test("match attributes and return attributes with match and andReturn methods", function (assert) {
     Ember.run(function () {
       var done = assert.async();
-      var date = new Date();
+      var date = new Date(2015,1,2,3,4,5);
       var customDescription = "special description";
       var company = make('company');
       var group = make('big-group');
 
       TestHelper.handleCreate('profile')
         .match({description: customDescription, company: company, group: group})
-        .andReturn({created_at: new Date()});
+        .andReturn({created_at: date});
 
       FactoryGuy.get('store').createRecord('profile', {
         description: customDescription, company: company, group: group


### PR DESCRIPTION
The `handleFindAll` function is a bit lacking in that all of the models it generates are identical (except for sequences).  This PR allows it to be called with a list of traits/options instead of a number.

```javascript
// findAll('user') will return Alice, Bob, and Charlotte (who is an admin)
TestHelper.handleFindAll('user', {name: 'Alice'}, {name: 'Bob'}, ['admin', {name: 'Charlotte'}]);
```
