### PR TITLE
Deprecates options succeed

### DIFF
--- a/addon/factory-guy-test-helper.js
+++ b/addon/factory-guy-test-helper.js
@@ -306,6 +306,7 @@ var FactoryGuyTestHelper = Ember.Object.create({
    should succeed ( default is true )
    */
   handleDelete: function (type, id, succeed) {
+    // TODO Turn this into a MockClass so it provides `andSuccess`, `andFail`, `returns`...
     succeed = succeed === undefined ? true : succeed;
     this.stubEndpointForHttpRequest(this.buildURL(type, id), null, {
       type: 'DELETE',

--- a/addon/mock-create-request.js
+++ b/addon/mock-create-request.js
@@ -46,8 +46,7 @@ var MockCreateRequest = function (url, modelName, options) {
     return this;
   };
 
-  this.andFail = function (options) {
-    options = options || {};
+  this.andFail = function (options = {}) {
     succeed = false;
     status = options.status || 500;
     if (options.response) {
@@ -58,14 +57,15 @@ var MockCreateRequest = function (url, modelName, options) {
   };
 
   // for supporting older ( non chaining methods ) style of passing in options
+  Ember.deprecate(
+    `[ember-data-factory-guy] TestHelper.handleCreate - options.succeed has been deprecated.
+      Use chainable methods with \`andFail()\` method instead`,
+    !options.hasOwnProperty('succeed'),
+    { id: 'ember-data-factory-guy.handle-create', until: '3.0.0' }
+  );
   if (succeed) {
     this.calculate();
   } else {
-    Ember.deprecate(
-      `[ember-data-factory-guy] TestHelper.handleCreate - options.succeed has been deprecated.
-        Use chainable methods with \`andFail()\` method instead`,
-      { id: 'ember-data-factory-guy.handle-create', until: '3.0.0' }
-    );
     this.andFail(options);
   }
 

--- a/addon/mock-create-request.js
+++ b/addon/mock-create-request.js
@@ -61,6 +61,11 @@ var MockCreateRequest = function (url, modelName, options) {
   if (succeed) {
     this.calculate();
   } else {
+    Ember.deprecate(
+      `[ember-data-factory-guy] TestHelper.handleCreate - options.succeed has been deprecated.
+        Use chainable methods with \`andFail()\` method instead`,
+      { id: 'ember-data-factory-guy.handle-create', until: '3.0.0' }
+    );
     this.andFail(options);
   }
 

--- a/addon/mock-update-request.js
+++ b/addon/mock-update-request.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import $ from 'jquery';
 import FactoryGuy from './factory-guy';
 
@@ -7,6 +8,12 @@ var MockUpdateRequest = function(url, model, options) {
   var response = null;
 
   if ('succeed' in options) {
+    Ember.deprecate(
+      `[ember-data-factory-guy] TestHelper.handleUpdate - options.succeed has been deprecated.
+        Use chainable methods with \`andFail()\` method instead`,
+      options.hasOwnProperty('succeed'),
+      { id: 'ember-data-factory-guy.handle-update', until: '3.0.0' }
+    );
     succeed = options.succeed;
   }
 

--- a/tests/unit/shared-factory-guy-test-helper-tests.js
+++ b/tests/unit/shared-factory-guy-test-helper-tests.js
@@ -689,7 +689,7 @@ SharedBehavior.handleCreateTests = function () {
   test("failure", function (assert) {
     Ember.run(function () {
       var done = assert.async();
-      TestHelper.handleCreate('profile', {succeed: false});
+      TestHelper.handleCreate('profile').andFail();
 
       FactoryGuy.get('store').createRecord('profile').save()
         .then(
@@ -736,8 +736,8 @@ SharedBehavior.handleCreateTests = function () {
       var description = "special description";
 
       TestHelper.handleCreate('profile', {
-        match: {description: description}, succeed: false
-      });
+        match: { description: description }
+      }).andFail();
 
       FactoryGuy.get('store').createRecord('profile', {description: description}).save()
         .then(
@@ -1024,7 +1024,7 @@ SharedBehavior.handleUpdateTests = function () {
       var done = assert.async();
       var profile = make('profile');
 
-      TestHelper.handleUpdate('profile', profile.id, {succeed: false, status: 500});
+      TestHelper.handleUpdate('profile', profile.id).andFail({ status: 500 });
 
       profile.set('description', 'new desc');
       profile.save().then(
@@ -1043,7 +1043,7 @@ SharedBehavior.handleUpdateTests = function () {
       var done = assert.async();
       var profile = make('profile');
 
-      TestHelper.handleUpdate(profile, {succeed: false, status: 500});
+      TestHelper.handleUpdate(profile).andFail({ status: 500 });
 
       profile.set('description', 'new desc');
       profile.save().then(
@@ -1062,8 +1062,7 @@ SharedBehavior.handleUpdateTests = function () {
       var done = assert.async();
       var profile = make('profile');
 
-      TestHelper.handleUpdate(profile, {
-        succeed: false,
+      TestHelper.handleUpdate(profile).andFail({
         status: 400,
         response: {errors: {description: 'invalid data'}}
       });


### PR DESCRIPTION
A small one, I saw your comment [here](https://github.com/danielspaniel/ember-data-factory-guy/compare/master...xcambar:deprecates_options_succeed?expand=1#diff-9872310e9a623729710540206c140e36R59) about supporting old non-chaining methods and thought that could be good to use `Ember.deprecate` to help developers migrate, or at least show them that it is deprecated.

FYI, I indicated version `3.0.0` as the limit of availability because it will be a breaking change, and I simply followed SemVer here.