### PR TITLE
Supporting nested query params comparisons in handleQuery

### DIFF
--- a/addon/mock-query-request.js
+++ b/addon/mock-query-request.js
@@ -13,6 +13,11 @@ function isEquivalent(a, b) {
 
   for (var i = 0; i < aProps.length; i++) {
     var propName = aProps[i];
+    var aEntry = a[propName];
+    var bEntry = b[propName];
+    if (Ember.typeOf(aEntry) === 'object' && Ember.typeOf(bEntry) === 'object') {
+      return isEquivalent(aEntry, bEntry);
+    }
 
     if (a[propName] !== b[propName]) {
       return false;

--- a/tests/unit/shared-factory-guy-test-helper-tests.js
+++ b/tests/unit/shared-factory-guy-test-helper-tests.js
@@ -526,8 +526,21 @@ SharedBehavior.handleQueryTests = function () {
       });
     });
   });
-};
 
+  test("Nested search params are ok", function (assert) {
+    Ember.run(function () {
+      var done = assert.async();
+
+      var madeCompanies = FactoryGuy.makeList('company', 2);
+
+      var queryHandler = TestHelper.handleQuery('company', {name: { like: 'Dude*' }}).returnsModels(madeCompanies);
+      FactoryGuy.get('store').query('company', {name: { like: 'Dude*' } }).then(function (companies) {
+        equal(companies.mapBy('id')+'', madeCompanies.mapBy('id')+'');
+        done();
+      });
+    });
+  });
+};
 
 /////// handleCreate //////////
 


### PR DESCRIPTION
Hi,

Migrating from 1.13.10 to 2.1.3 I noticed that handleQuery no longer works for nested query parameters


   TestHelper.handleQuery('foo', { a: { b: 'c' } })
   ...
   this.store.query('foo', { a: { b: 'c' } })


from https://github.com/danielspaniel/ember-data-factory-guy/commit/fcce319a96262cbfbd63ad9b28d73e60d977436f I'd say it's not on purpose.

This adds support for this case that is not so uncommon.