### PR TITLE
build(): apply transform of custom type when serializing attributes

### DIFF
--- a/tests/unit/active-model-adapter-test.js
+++ b/tests/unit/active-model-adapter-test.js
@@ -117,3 +117,18 @@ test("using custom serialize keys function for transforming attributes and relat
   serializer.keyForAttribute = savedKeyForAttributeFn;
   serializer.keyForRelationship = savedKeyForRelationshipFn;
 });
+
+test("serializes attributes with custom type", function () {
+  var info = {first: 1};
+  var buildJson = build('user', {info: info});
+
+  var expectedJson = {
+    user: {
+      id: 1,
+      name: 'User1',
+      info: '{"first":1}'
+    }
+  };
+
+  deepEqual(buildJson, expectedJson);
+});

--- a/tests/unit/jsonapi-adapter-test.js
+++ b/tests/unit/jsonapi-adapter-test.js
@@ -384,6 +384,24 @@ test("using custom serialize keys function for transforming attributes and relat
 
 });
 
+test("serializes attributes with custom type", function () {
+  var info = {first: 1};
+  var json = build('user', {info: info});
+
+  deepEqual(json,
+    {
+      data: {
+        id: 1,
+        type: 'user',
+        attributes: {
+          name: 'User1',
+          info: '{"first":1}'
+        }
+      }
+    }
+  );
+});
+
 test("with (nested json fixture) belongsTo has a hasMany association which has a belongsTo", function () {
 
   var expectedData = {


### PR DESCRIPTION
Ember-Data models can have attributes defined with a custom type, which [applies a transform](https://guides.emberjs.com/v2.0.0/models/defining-models/#toc_transforms) when the attribute is serialized or deserialized.

For now, Ember-Data-Factory-Guy's `make()` already support these kind of custom attributes. But `build()` just ignores the transform, and puts the raw attribute value in the generated payload.

This MR makes `RESTFixtureConverter` and `JSONAPIFixtureConverter` aware of transformed attributes.

```c
// model/user.js
export DS.Model.extend({
  info: attr('object'),
});

// transform/object.js
export DS.Transform.extend({
  serialize: function(deserialized) {
    return deserialized ? JSON.stringify(deserialized) : "{}"
  }
});

// Tests
build('user', {info: {first: 1}} );
var expectedJson = {
  user: {
    id: 1,
    info: '{"first":1}' // info is now correctly serialized as a string (instead of being a hash)
  }
};
```
