### PR TITLE
Fix compatibility with ember-data-model-fragments

### DIFF
--- a/tests/dummy/app/models/profile.js
+++ b/tests/dummy/app/models/profile.js
@@ -6,6 +6,7 @@ export default DS.Model.extend({
   camelCaseDescription:   DS.attr('string'),
   snake_case_description: DS.attr('string'),
   aBooleanField:          DS.attr('boolean'),
+  foo:                    DS.attr('just-a-string'),
   superHero:              DS.belongsTo('super-hero', {async: false}),
   company:                DS.belongsTo('company', {async: false}),
   group:                  DS.belongsTo('group', {async: false, polymorphic: true})

--- a/tests/dummy/app/serializers/profile.js
+++ b/tests/dummy/app/serializers/profile.js
@@ -1,0 +1,12 @@
+import DS from 'ember-data';
+
+export default DS.JSONAPISerializer.extend({
+  transformFor: function (attributeType) {
+    if (attributeType === 'just-a-string') {
+      return this.container.lookup('transform:string');
+    }
+    else {
+      return this._super.apply(this, arguments);
+    }
+  }
+});

--- a/tests/dummy/app/transforms/just-a-string.js
+++ b/tests/dummy/app/transforms/just-a-string.js
@@ -1,0 +1,11 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+
+export default DS.Transform.extend({
+  serialize: function(value) {
+    return 'failed';
+  },
+  deserialize: function(value) {
+    return 'failed';
+  }
+});

--- a/tests/unit/models/profile-test.js
+++ b/tests/unit/models/profile-test.js
@@ -24,3 +24,8 @@ test('using this.subject for profile and make for company associaion', function(
   let profile = this.subject({company: make('company')});
   ok(profile.get('company.profile') === profile);
 });
+
+test('uses customized transformFor', function () {
+  let profile = make('profile', {foo: 'bar'});
+  equal(profile.get('foo'), 'bar');
+});


### PR DESCRIPTION
This adds a workaround for compatibility with ember-data-model-fragments, as discussed in #182.

@patocallaghan you mentioned that the workaround did not work for you before, could you try this branch when you have the time? (you'll need to use `"ember-data-factory-guy": "whatthewhat/ember-data-factory-guy#model-fragments-compatibility"` in your package.json)
I only tested it on 1 app, but it seems to be working ok with ember-data-model-fragments 1.13.1 and ember-data 1.13.16

Closes #182 