### PR TITLE
Added tests for Ember Data Model Fragment factory support in unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "active-model-adapter": "2.0.3",
     "broccoli-asset-rev": "^2.1.2",
     "ember-cli": "^2.3.0-beta.2",
-    "ember-load-initializers": "^0.5.0",
     "ember-cli-app-version": "0.5.0",
     "ember-cli-babel": "latest",
     "ember-cli-content-security-policy": "0.4.0",
@@ -38,7 +37,9 @@
     "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "1.2.0",
     "ember-data": "2.3.3",
+    "ember-data-model-fragments": "2.3.0",
     "ember-export-application-global": "latest",
+    "ember-load-initializers": "^0.5.0",
     "ember-resolver": "2.0.3",
     "ember-sinon": "0.0.3",
     "loader.js": "ember-cli/loader.js#v4.0.0"

--- a/tests/acceptance/employee-view-test.js
+++ b/tests/acceptance/employee-view-test.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+const { run } = Ember;
+import { make, build, buildList, mockFind, mockCreate } from 'ember-data-factory-guy';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | Employee View');
+// NOTE
+// FactoryGuy before and after setup is in moduleForAcceptance helper
+
+test("Show employee by make(ing) a model and using returns with that model", function () {
+  // make a user with projects ( which will be in the store )
+  // if you need the computed properties on the model this is best bet
+  let name;
+  let departmentEmployments;
+  let employee = make('employee', 'with_department_employments');
+  run(() => {
+    name = employee.get('name');
+    departmentEmployments = employee.get('departmentEmployments');
+  });
+
+  mockFind('employee').returns({model: employee});
+
+  visit('/employee/' + employee.get('id'));
+
+  andThen(()=>{
+    ok(find('.name').text().match(`${employee.get('name.firstName')} ${employee.get('name.lastName')}`));
+  });
+});

--- a/tests/dummy/app/components/single-employee.js
+++ b/tests/dummy/app/components/single-employee.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['employee']
+});
+

--- a/tests/dummy/app/models/billing-address.js
+++ b/tests/dummy/app/models/billing-address.js
@@ -1,0 +1,6 @@
+import attr from 'ember-data/attr';
+import Address from 'dummy/models/nested-fragment/address';
+
+export default Address.extend({
+  billingAddressProperty: attr('number')
+});

--- a/tests/dummy/app/models/department-employment.js
+++ b/tests/dummy/app/models/department-employment.js
@@ -1,0 +1,12 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+import Fragment from 'model-fragments/fragment';
+import {
+  fragment
+} from 'model-fragments/attributes';
+
+export default Fragment.extend({
+  startDate: attr('date'),
+  endDate: attr('date'),
+  department: fragment('department')
+});

--- a/tests/dummy/app/models/department.js
+++ b/tests/dummy/app/models/department.js
@@ -1,0 +1,11 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+import Fragment from 'model-fragments/fragment';
+import {
+  fragmentArray
+} from 'model-fragments/attributes';
+
+export default Fragment.extend({
+  name: attr('string'),
+  addresses: fragmentArray('nested-fragment/address', { polymorphic: true, typeKey: '$type' })
+});

--- a/tests/dummy/app/models/employee.js
+++ b/tests/dummy/app/models/employee.js
@@ -1,0 +1,15 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+import {
+  array,
+  fragment,
+  fragmentArray
+} from 'model-fragments/attributes';
+
+export default Model.extend({
+  name      : fragment('name'),
+  titles    : array('string'),
+  gender    : attr('string'),
+  birthDate: attr('date'),
+  departmentEmployments : fragmentArray('department-employment')
+});

--- a/tests/dummy/app/models/mailing-address.js
+++ b/tests/dummy/app/models/mailing-address.js
@@ -1,0 +1,6 @@
+import attr from 'ember-data/attr';
+import Address from 'dummy/models/nested-fragment/address';
+
+export default Address.extend({
+  mailingAddressProperty: attr('number')
+});

--- a/tests/dummy/app/models/name.js
+++ b/tests/dummy/app/models/name.js
@@ -1,0 +1,7 @@
+import attr from 'ember-data/attr';
+import Fragment from 'model-fragments/fragment';
+
+export default Fragment.extend({
+  firstName : attr('string'),
+  lastName  : attr('string')
+});

--- a/tests/dummy/app/models/nested-fragment/address.js
+++ b/tests/dummy/app/models/nested-fragment/address.js
@@ -1,0 +1,9 @@
+import attr from 'ember-data/attr';
+import Fragment from 'model-fragments/fragment';
+
+export default Fragment.extend({
+  street  : attr('string'),
+  city    : attr('string'),
+  region  : attr('string'),
+  country : attr('string')
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,6 +8,7 @@ var Router = Ember.Router.extend({
 Router.map(function() {
   this.route('users');
   this.route('profiles');
+  this.route('employees');
   this.route('user', {path: '/user/:user_id'});
   this.route('search', {path: '/search'}, function() {
     this.route('results', {path: ':name'});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,6 +9,7 @@ Router.map(function() {
   this.route('users');
   this.route('profiles');
   this.route('employees');
+  this.route('employee', {path: '/employee/:employee_id'});
   this.route('user', {path: '/user/:user_id'});
   this.route('search', {path: '/search'}, function() {
     this.route('results', {path: ':name'});

--- a/tests/dummy/app/routes/employees.js
+++ b/tests/dummy/app/routes/employees.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/templates/components/single-employee.hbs
+++ b/tests/dummy/app/templates/components/single-employee.hbs
@@ -1,0 +1,34 @@
+<h3>Employee</h3>
+<p class="name">Name: {{employee.name.firstName}} {{employee.name.lastName}}</p>
+
+<p class="titles">Titles:
+{{#each employee.titles as |title|}}
+  {{title}}<br>
+{{/each}}
+</p>
+
+<p class="gender">Gender: {{employee.gender}}</p>
+
+<p class="birthdate">DOB: {{employee.birthDate}}</p>
+
+<div class="department-employments">
+{{#each employee.departmentEmployments as |employment|}}
+  <div class="department-employments">
+    <p class="department">department: {{employment.department.name}}</p>
+    <p class="start-date">startDate: {{employment.startDate}}</p>
+    <p class="end-date">endDate: {{employment.endDate}}</p>
+
+    <div class="addresses">
+      {{#each employment.department.addresses as |address|}}
+        <p class="address">
+          <span class="street">{{address.street}}</span>
+          <span class="city">{{address.city}}</span>
+          <span class="region">{{address.region}}</span>
+          <span class="country">{{address.country}}</span>
+        </p>
+        <hr>
+      {{/each}}
+    </div>
+  </div>
+{{/each}}
+</div>

--- a/tests/dummy/app/templates/employee.hbs
+++ b/tests/dummy/app/templates/employee.hbs
@@ -1,0 +1,1 @@
+{{single-employee employee=model}}

--- a/tests/dummy/app/templates/employees.js
+++ b/tests/dummy/app/templates/employees.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-data-factory-guy/templates/employees';

--- a/tests/dummy/app/templates/employees.js
+++ b/tests/dummy/app/templates/employees.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-factory-guy/templates/employees';

--- a/tests/dummy/app/tests/factories/address.js
+++ b/tests/dummy/app/tests/factories/address.js
@@ -1,0 +1,13 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('nested-fragment/address', {
+  sequences: {
+    house: (num) => `${num} Sky Cell`
+  },
+  default: {
+    street: FactoryGuy.generate('house'),
+    city: "Eyre",
+    region: "Vale of Arryn",
+    country: "Westeros"
+  }
+});

--- a/tests/dummy/app/tests/factories/billing-address.js
+++ b/tests/dummy/app/tests/factories/billing-address.js
@@ -1,0 +1,7 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('billing-address', {
+  default: {
+    billingAddressProperty: FactoryGuy.generate((num) => num),
+  }
+});

--- a/tests/dummy/app/tests/factories/department-employment.js
+++ b/tests/dummy/app/tests/factories/department-employment.js
@@ -1,0 +1,9 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('department-employment', {
+  default: {
+    startDate: new Date('2015-01-01'),
+    endDate: new Date('2016-01-01'),
+    department: FactoryGuy.belongsTo('department')
+  }
+});

--- a/tests/dummy/app/tests/factories/department.js
+++ b/tests/dummy/app/tests/factories/department.js
@@ -1,0 +1,8 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('department', {
+  default: {
+    name: FactoryGuy.generate((num) => `Acme Dept ${num}`),
+    addresses: FactoryGuy.hasMany('nested-fragment/address', 3)
+  }
+});

--- a/tests/dummy/app/tests/factories/employee.js
+++ b/tests/dummy/app/tests/factories/employee.js
@@ -1,0 +1,28 @@
+import FactoryGuy from 'ember-data-factory-guy';
+import { make } from 'ember-data-factory-guy';
+
+FactoryGuy.define('employee', {
+  default: {
+    name: FactoryGuy.belongsTo('name'),
+    titles: ['Mr.', 'Dr.'],
+    gender: 'Male',
+    birthDate: new Date()
+  },
+  traits: {
+    default_name_setup: {
+      name: {}
+    },
+    jon: {
+      name: {
+        firstName: 'Jon',
+        lastName: 'Snow'
+      }
+    },
+    geoffrey: {
+      name: FactoryGuy.belongsTo('employee_geoffrey')
+    },
+    with_department_employments: {
+      departmentEmployments: FactoryGuy.hasMany('department-employment', 2),
+    }
+  }
+});

--- a/tests/dummy/app/tests/factories/mailing-address.js
+++ b/tests/dummy/app/tests/factories/mailing-address.js
@@ -1,0 +1,7 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('mailing-address', {
+  default: {
+    mailingAddressProperty: FactoryGuy.generate((num) => num),
+  }
+});

--- a/tests/dummy/app/tests/factories/name.js
+++ b/tests/dummy/app/tests/factories/name.js
@@ -1,0 +1,17 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('name', {
+  default: {
+    firstName: 'Tyrion',
+    lastName: 'Lannister'
+  },
+  employee_geoffrey: {
+    firstName: 'Geoffrey',
+    lastName: 'Lannister'
+  },
+  traits: {
+    kingslayer: {
+      firstName: 'Jamie'
+    }
+  }
+});

--- a/tests/unit/models/employee-test.js
+++ b/tests/unit/models/employee-test.js
@@ -72,7 +72,7 @@ test('employee with department employments (fragment arrays)', function() {
     let department2 = employee.get('departmentEmployments').objectAt(1).get('department');
     ok(department1.get('name') === 'Acme Dept 1');
     ok(department2.get('name') === 'Acme Dept 2');
-    let addresses = department1.get('addresses')
+    let addresses = department1.get('addresses');
     ok(addresses.get('length') === 3);
     ok(addresses.get('firstObject.street') === '1 Sky Cell');
     ok(addresses.get('lastObject.street') === '3 Sky Cell');

--- a/tests/unit/models/employee-test.js
+++ b/tests/unit/models/employee-test.js
@@ -1,10 +1,20 @@
-import { manualSetup, make, makeList } from 'ember-data-factory-guy';
+import { mockUpdate, manualSetup, make, makeList } from 'ember-data-factory-guy';
 import { test, moduleForModel } from 'ember-qunit';
 import Ember from 'ember';
 const { run } = Ember;
 
 moduleForModel('employee', 'Unit | Model | employee', {
-  needs: ['model:name', 'model:department-employment', 'model:department', 'model:nested-fragment/address', 'model:mailing-address', 'model:billing-address'],
+  needs: [
+    'model:name',
+    'model:department-employment',
+    'model:department',
+    'model:nested-fragment/address',
+    'model:mailing-address',
+    'model:billing-address',
+    'transform:fragment',
+    'transform:fragment-array',
+    'transform:array'
+  ],
 
   beforeEach: function() {
     manualSetup(this.container);
@@ -18,6 +28,21 @@ test('default employee', function() {
   run(() => {
     ok(employee.get('name.firstName') === 'Tyrion');
     ok(employee.get('name.lastName') === 'Lannister');
+  });
+});
+
+//MOCK UPDATE TEST
+test('update the employee', function() {
+  let employee = make('employee');
+  mockUpdate(employee);
+  run(() => {
+    ok(!employee.get('hasDirtyAttributes'));
+    employee.set('name.firstName', 'Jamie');
+    ok(employee.get('name.firstName') === 'Jamie');
+    ok(employee.get('name.lastName') === 'Lannister');
+    ok(employee.get('hasDirtyAttributes'));
+    employee.save();
+    ok(!employee.get('hasDirtyAttributes'));
   });
 });
 

--- a/tests/unit/models/employee-test.js
+++ b/tests/unit/models/employee-test.js
@@ -1,0 +1,80 @@
+import { manualSetup, make, makeList } from 'ember-data-factory-guy';
+import { test, moduleForModel } from 'ember-qunit';
+import Ember from 'ember';
+const { run } = Ember;
+
+moduleForModel('employee', 'Unit | Model | employee', {
+  needs: ['model:name', 'model:department-employment', 'model:department', 'model:nested-fragment/address', 'model:mailing-address', 'model:billing-address'],
+
+  beforeEach: function() {
+    manualSetup(this.container);
+  }
+});
+
+// NAME FRAGMENT
+test('default employee', function() {
+  let employee = make('employee');
+  //Should I need a run loop?
+  run(() => {
+    ok(employee.get('name.firstName') === 'Tyrion');
+    ok(employee.get('name.lastName') === 'Lannister');
+  });
+});
+
+test('employee with default name trait', function() {
+  let employee = make('employee', 'default_name_setup');
+  //Fails because name is defined with {}, should it not be the default name factory?
+  run(() => {
+    ok(employee.get('name.firstName') === 'Tyrion');
+    ok(employee.get('name.lastName') === 'Lannister');
+  });
+});
+
+test('default employee with trait with custom name fragment', function() {
+  let employee = make('employee', 'jon');
+  run(() => {
+    ok(employee.get('name.firstName') === 'Jon');
+    ok(employee.get('name.lastName') === 'Snow');
+  });
+});
+
+test('default employee with trait with custom name belongsTo', function() {
+  let employee = make('employee', 'geoffrey');
+  run(() => {
+    ok(employee.get('name.firstName') === 'Geoffrey');
+    ok(employee.get('name.lastName') === 'Lannister');
+  });
+});
+
+test('manual setting up employee name', function() {
+  let employee = make('employee', 'geoffrey');
+  run(() => {
+    ok(employee.get('name.firstName') === 'Geoffrey');
+    ok(employee.get('name.lastName') === 'Lannister');
+  });
+});
+
+// TITLES FRAGMENT
+test('default employee and titles', function() {
+  let employee = make('employee');
+  run(() => {
+    ok(employee.get('titles.length') === 2);
+    deepEqual(employee.get('titles.content'), ['Mr.', 'Dr.']);
+  });
+});
+
+// DEPARTMENT EMPLOYMENT
+test('employee with department employments (fragment arrays)', function() {
+  let employee = make('employee', 'with_department_employments');
+  run(() => {
+    ok(employee.get('departmentEmployments.length') === 2);
+    let department1 = employee.get('departmentEmployments.firstObject.department');
+    let department2 = employee.get('departmentEmployments').objectAt(1).get('department');
+    ok(department1.get('name') === 'Acme Dept 1');
+    ok(department2.get('name') === 'Acme Dept 2');
+    let addresses = department1.get('addresses')
+    ok(addresses.get('length') === 3);
+    ok(addresses.get('firstObject.street') === '1 Sky Cell');
+    ok(addresses.get('lastObject.street') === '3 Sky Cell');
+  });
+});


### PR DESCRIPTION
As discussed in #184 I've added unit tests to test for support of https://github.com/lytics/ember-data-model-fragments. It's not comprehensive but it's a start. Acceptance tests can follow.

I've added an `employee` model which from a `model-fragment` point of view looks like:

```
Employee
* name (fragment)
* titles (array)
* departmentEmployments (fragmentArray)

  DepartmentEmployment
  * department (fragment)

    Department
    * addresses (fragmentArray)
```

As `model-fragment` supports polymorphic `fragmentArrays` I added `billing-address` and `mailing-address` as well but was unsure how to construct the list using a factory to test it.

@danielspaniel anything else you think we should test for?