### PR TITLE
refactor the equivalence function so that it works with arrays as well

### DIFF
--- a/addon/utils/helper-functions.js
+++ b/addon/utils/helper-functions.js
@@ -1,28 +1,36 @@
 import Ember from 'ember';
 
-// compare to object for loose equality
-let isEquivalent = function(a, b) {
-
-  let aProps = Object.keys(a);
-  let bProps = Object.keys(b);
-
-  if (aProps.length !== bProps.length) {
-    return false;
+function isEquivalent(a, b) {
+  var type = Ember.typeOf(a);
+  if(type !== Ember.typeOf(b)) { return false; }
+  switch (type) {
+    case 'object':
+      return objectIsEquivalent(a, b);
+    case 'array':
+      return arrayIsEquivalent(a, b);
+    default:
+      return a === b;
   }
+}
 
+function arrayIsEquivalent(arrayA , arrayB) {
+  if(arrayA.length !== arrayB.length) { return false; }
+  return arrayA.every(function(item, index) {
+    return isEquivalent(item, arrayB[index]);
+  });
+}
+
+function objectIsEquivalent(objectA, objectB) {
+  var aProps = Object.keys(objectA);
+  var bProps = Object.keys(objectB);
+  if (aProps.length !== bProps.length) { return false; }
   for (let i = 0; i < aProps.length; i++) {
     let propName = aProps[i];
-    let aEntry = a[propName];
-    let bEntry = b[propName];
-    if (Ember.typeOf(aEntry) === 'object' && Ember.typeOf(bEntry) === 'object') {
-      return isEquivalent(aEntry, bEntry);
-    }
-
-    if (a[propName] !== b[propName]) {
-      return false;
-    }
+    let aEntry   = objectA[propName];
+    let bEntry   = objectB[propName];
+    if(!isEquivalent(aEntry, bEntry)) { return false; }
   }
   return true;
-};
+}
 
 export { isEquivalent };

--- a/tests/unit/utils/helper-functions-test.js
+++ b/tests/unit/utils/helper-functions-test.js
@@ -1,0 +1,103 @@
+import { module, test } from 'qunit';
+import { isEquivalent } from 'ember-data-factory-guy/utils/helper-functions';
+
+module('isEquivalent | Helper Function');
+
+var tomster = { name: 'Tomster', friends: ['Zoey',    'Yahuda', 'Tom'] };
+var zoey    = { name: 'Zoey',    friends: ['Tomster', 'Yahuda', 'Tom'] };
+var daniel  = { name: 'Daniel',  friends: ['Zoey',    'Yahuda', 'Tom'] };
+
+test('#isEquivalent with numbers', function(assert) {
+  assert.ok(  isEquivalent(1, 1),   'Equivalent numbers should return true'      );
+
+  assert.ok( !isEquivalent(1, 2),   'Non-equivalent numbers should return false' );
+  assert.ok( !isEquivalent(1, '1'), 'Non-equivalent values should return false'  );
+});
+
+test('#isEquivalent with strings', function(assert) {
+  assert.ok(  isEquivalent(tomster.name, 'Tomster'), 'Equivalent strings should return true' );
+
+  assert.ok( !isEquivalent(zoey.name,    'Tomster'), 'Non-equivalent strings should return false' );
+});
+
+test('#isEquivalent with booleans', function(assert) {
+  assert.ok(  isEquivalent(true, true),   'true === true'  );
+  assert.ok(  isEquivalent(false, false), 'false === false');
+
+  assert.ok( !isEquivalent(true, false),  'true !== false' );
+  assert.ok( !isEquivalent(true, 1),      'true !== 1'     );
+  assert.ok( !isEquivalent(true, 'true'), 'true !== 1'     );
+});
+
+test('#isEquivalent with arrays', function(assert) {
+  assert.ok(  isEquivalent(tomster.friends, daniel.friends), 'arrays with equivalent contents in the same order return true' );
+
+  assert.ok( !isEquivalent(tomster.friends, zoey.friends),   'arrays with non-equivalent contents return false' );
+  assert.ok( !isEquivalent(tomster.friends, ['Zoey', 'Tom', 'Yahuda']), 'arrays with equivalent contents but in a different order return false' );
+
+  assert.ok( isEquivalent([
+    1,
+    [
+      'a',
+      [ true ]
+    ]
+  ],
+  [
+    1,
+    [
+      'a',
+      [ true ]
+    ]
+  ]), 'matches equivalence on deeply nested arrays');
+
+  assert.ok( !isEquivalent([
+    1,
+    [
+      'a',
+      [ true ]
+    ]
+  ],
+  [
+    1,
+    [
+      'b',
+      [ true ]
+    ]
+  ]), 'filters equivalence on deeply nested arrays');
+});
+
+test('#isEquivalent with objects', function(assert) {
+  assert.ok(  isEquivalent(tomster, {
+    name: 'Tomster',
+    friends: ['Zoey', 'Yahuda', 'Tom']
+  }), 'returns true if object key-value pairs are equivalent' );
+
+  assert.ok( !isEquivalent(tomster, zoey), 'returns false if object key-value pairs are not equivalent' );
+
+  assert.ok( !isEquivalent(tomster, {
+    name: 'Tomster',
+    friends: ['Zoey', 'Daniel', 'Tom']
+  }), 'returns false if object key-value pairs are not equivalent' );
+});
+
+test('#isEquivalent with deeply nested objects', function(assert) {
+  // we don't use nestedTomster or nestedZoey in the friends array to avoid
+  // infinite recurrsion
+
+  var nestedTomster = {
+    name:    tomster.name,
+    friends: [ zoey, daniel ]
+  };
+
+  var nestedZoey = {
+    name:    zoey.name,
+    friends: [ tomster, daniel ]
+  };
+
+  assert.ok( isEquivalent(nestedTomster, {
+    name:    tomster.name,
+    friends: [ zoey, daniel ]
+  }), 'returns true if object key-value pairs are equivalent' );
+
+  assert.ok( !isEquivalent(nestedZoey, nestedTomster), 'returns false if object key-value pairs are not equivalent' );
+});


### PR DESCRIPTION
Currently, array parameters do not work for `mockQuery` because this tests strict equivalence versus the contents of the array.

This PR addresses the issue by breaking the `isEquivalent` function into three pieces and then makes use of recursion to deal with nested equality.

The three pieces are: 

1. Object Equivalence - slightly modified take on your algorithm 
2. Array Equivalence - contents and order of `arrayA` are identical to contents and order of `arrayB`
3. Normal Strict Equivalence `===` 

I would like some feedback on how you would like me to test the array case, since `user-search-test` is using `fillIn` and we need an array and an object as a param.

### Left to Do
- [ ] Match the JS Style to your repo's style
- [x] Tests that deal with nested objects and arrays