### PR TITLE
Wrap arrays that use prototype extensions in Ember.A()

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -517,7 +517,7 @@ class FactoryGuy {
       let adapter = findAdapter(name);
       let shouldCache = ()=> {
         if (Ember.isPresent(except)) {
-           return (except.contains(name));
+           return (Ember.A(except).contains(name));
         }
         return false;
       };

--- a/addon/mocks/mock-get-request.js
+++ b/addon/mocks/mock-get-request.js
@@ -28,7 +28,7 @@ class MockGetRequest {
     const [ responseKey ] = responseKeys;
     Ember.assert(`[ember-data-factory-guy] You passed an invalid key for 'returns' function.
       Valid keys are ${this.validReturnsKeys}. You used this key: ${responseKey}`,
-      this.validReturnsKeys.contains(responseKey));
+      Ember.A(this.validReturnsKeys).contains(responseKey));
 
     return responseKey;
   }

--- a/addon/payload/rest-payload.js
+++ b/addon/payload/rest-payload.js
@@ -11,7 +11,7 @@ export default class extends JSONPayload {
   add(moreJson) {
     this.converter.included = this.json;
     Object.keys(moreJson)
-      .reject(key=> this.proxyMethods.contains(key))
+      .reject(key=> Ember.A(this.proxyMethods).contains(key))
       .forEach(key=> {
         if (Ember.typeOf(moreJson[key]) === "array") {
           moreJson[key].forEach(data=> this.converter.addToIncluded(data, key));
@@ -25,7 +25,7 @@ export default class extends JSONPayload {
   includeKeys() {
     return Object.keys(this.json)
         .reject(key => this.payloadKey === key)
-        .reject(key=> this.proxyMethods.contains(key)) ||
+        .reject(key=> Ember.A(this.proxyMethods).contains(key)) ||
       [];
   }
 


### PR DESCRIPTION
Continuation of #114 #78 