### PR TITLE
Fix type.match crasher

### DIFF
--- a/addon/converter/fixture-converter.js
+++ b/addon/converter/fixture-converter.js
@@ -29,7 +29,7 @@ export default class {
   }
 
   getTransformValueFunction(type) {
-    if (!this.transformKeys || type.match('-mf')) {
+    if (!this.transformKeys || (type && type.match('-mf'))) {
       return this.noTransformFn;
     }
     if (!type) {

--- a/tests/dummy/app/models/employee.js
+++ b/tests/dummy/app/models/employee.js
@@ -11,5 +11,6 @@ export default Model.extend({
   titles    : array('string'),
   gender    : attr('string'),
   birthDate: attr('date'),
+  position: attr(),
   departmentEmployments : fragmentArray('department-employment')
 });


### PR DESCRIPTION
Ember Data allows you to do: `name: DS.attr()` without specifying a type for the attribute.

In some circumstances having no type set would cause your tests to crash on the following line: https://github.com/danielspaniel/ember-data-factory-guy/blob/master/addon/converter/fixture-converter.js#L32 because `this.transformKeys` was `true` but `type` was `undefined`.

```
if (!this.transformKeys || type.match('-mf')) {
  return this.noTransformFn;
}
```

Adding `position: attr()` caused the [employee acceptance test](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/acceptance/employee-view-test.js#L10) to break. This fix makes it pass.