### PR TITLE
Support embedding records using `deserialize: 'records'`

### DIFF
--- a/addon/converter/fixture-converter.js
+++ b/addon/converter/fixture-converter.js
@@ -102,7 +102,7 @@ export default class {
   isEmbeddedRelationship(modelName, attr) {
     let serializer = this.store.serializerFor(modelName);
     var option = this.attrsOption(serializer, attr);
-    return option && option.embedded === 'always';
+    return option && (option.embedded === 'always' || option.deserialize === 'records');
   }
 
   attrsOption(serializer, attr) {

--- a/tests/dummy/app/models/employee.js
+++ b/tests/dummy/app/models/employee.js
@@ -1,5 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
+import { hasMany, belongsTo } from 'ember-data/relationships';
 import {
   array,
   fragment,

--- a/tests/dummy/app/models/manager.js
+++ b/tests/dummy/app/models/manager.js
@@ -1,0 +1,9 @@
+import Model from 'ember-data/model';
+import { hasMany, belongsTo } from 'ember-data/relationships';
+import { fragment } from 'model-fragments/attributes';
+
+export default Model.extend({
+  name      : fragment('name'),
+  salary: belongsTo('salary'),
+  reviews: hasMany('review')
+});

--- a/tests/dummy/app/models/review.js
+++ b/tests/dummy/app/models/review.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  rating: DS.attr('number'),
+  date: DS.attr('date')
+});

--- a/tests/dummy/app/models/salary.js
+++ b/tests/dummy/app/models/salary.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+import { array } from 'model-fragments/attributes';
+
+export default DS.Model.extend({
+  income: DS.attr('number'),
+  benefits: array('string')
+});

--- a/tests/dummy/app/serializers/manager.js
+++ b/tests/dummy/app/serializers/manager.js
@@ -1,0 +1,14 @@
+import DS from 'ember-data';
+
+export default DS.RESTSerializer.extend(DS.EmbeddedRecordsMixin,{
+  attrs: {
+    salary: {
+      serialize: true,
+      deserialize: 'records'
+    },
+    reviews: {
+      serialize: true,
+      deserialize: 'records'
+    }
+  }
+});

--- a/tests/dummy/app/tests/factories/employee.js
+++ b/tests/dummy/app/tests/factories/employee.js
@@ -1,12 +1,11 @@
 import FactoryGuy from 'ember-data-factory-guy';
-import { make } from 'ember-data-factory-guy';
 
 FactoryGuy.define('employee', {
   default: {
     name: FactoryGuy.belongsTo('name'),
     titles: ['Mr.', 'Dr.'],
     gender: 'Male',
-    birthDate: new Date()
+    birthDate: new Date('2016-05-01')
   },
   traits: {
     default_name_setup: {

--- a/tests/dummy/app/tests/factories/manager.js
+++ b/tests/dummy/app/tests/factories/manager.js
@@ -1,0 +1,18 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('manager', {
+  default: {
+    name: FactoryGuy.belongsTo('name')
+  },
+  traits: {
+    default_name_setup: {
+      name: {}
+    },
+    with_salary: {
+      salary: FactoryGuy.belongsTo('salary')
+    },
+    with_reviews: {
+      reviews: FactoryGuy.hasMany('review', 2)
+    }
+  }
+});

--- a/tests/dummy/app/tests/factories/review.js
+++ b/tests/dummy/app/tests/factories/review.js
@@ -1,0 +1,8 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('review', {
+  default: {
+    rating: FactoryGuy.generate((num)=> num),
+    date: new Date('2015-05-01')
+  }
+});

--- a/tests/dummy/app/tests/factories/salary.js
+++ b/tests/dummy/app/tests/factories/salary.js
@@ -1,0 +1,8 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('salary', {
+  default: {
+    income: 90000,
+    benefits: ['health', 'company car', 'dental']
+  }
+});

--- a/tests/helpers/utility-methods.js
+++ b/tests/helpers/utility-methods.js
@@ -19,7 +19,7 @@ let theUsualSetup = function (adapterType) {
     // comic book will always be REST style serializer
     store.serializerFor = function(modelName) {
       let originalSerializer = findSerializer(modelName);
-      if (modelName.match(/(comic-book|name|department|address|department-employment)/)) {
+      if (modelName.match(/(comic-book|name|department|address|department-employment|manager)/)) {
         return originalSerializer;
       }
       return serializer;

--- a/tests/unit/rest-adapter-test.js
+++ b/tests/unit/rest-adapter-test.js
@@ -436,6 +436,115 @@ test("embeds hasMany records passed as prebuilt ( buildList ) json when serializ
   deepEqual(buildJson, expectedJson);
 });
 
+test("embeds belongsTo record when serializer attrs => deserialize: 'records' ", function () {
+
+  let buildJson = build('manager', 'with_salary');
+  buildJson.unwrap();
+
+  let expectedJson = {
+    manager: {
+      id: 1,
+      name: {
+        firstName: "Tyrion",
+        id: 1,
+        lastName: "Lannister"
+      },
+      salary: {
+        id: 1,
+        income: 90000,
+        benefits: ['health', 'company car', 'dental']
+      }
+    }
+  };
+
+  deepEqual(buildJson, expectedJson);
+});
+
+test("embeds belongsTo record passed as prebuilt ( build ) json when serializer attrs => deserialize: 'records' ", function () {
+  let salary = build('salary');
+  let buildJson = build('manager', {salary: salary});
+  buildJson.unwrap();
+
+  let expectedJson = {
+    manager: {
+      id: 1,
+      name: {
+        firstName: "Tyrion",
+        id: 1,
+        lastName: "Lannister"
+      },
+      salary: {
+        id: 1,
+        income: 90000,
+        benefits: ['health', 'company car', 'dental']
+      }
+    }
+  };
+
+  deepEqual(buildJson, expectedJson);
+});
+
+test("embeds hasMany records when serializer attrs => deserialize: 'records'", function () {
+
+  let buildJson = build('manager', 'with_reviews');
+  buildJson.unwrap();
+
+  let expectedJson = {
+    manager: {
+      id: 1,
+      name: {
+        firstName: "Tyrion",
+        id: 1,
+        lastName: "Lannister"
+      },
+      reviews: [
+        {
+          id: 1,
+          rating: 1,
+          date: "2015-05-01T00:00:00.000Z"
+        },
+        {
+          id: 2,
+          rating: 2,
+          date: "2015-05-01T00:00:00.000Z"
+        }
+      ]
+    }
+  };
+
+  deepEqual(buildJson, expectedJson);
+});
+
+test("embeds hasMany records passed as prebuilt ( buildList ) json when serializer attrs => deserialize: 'records'", function () {
+  let reviews = buildList('review', 2);
+  let buildJson = build('manager', {reviews: reviews});
+  buildJson.unwrap();
+
+  let expectedJson = {
+    manager: {
+      id: 1,
+      name: {
+        firstName: "Tyrion",
+        id: 1,
+        lastName: "Lannister"
+      },
+      reviews: [
+        {
+          id: 1,
+          rating: 1,
+          date: "2015-05-01T00:00:00.000Z"
+        },
+        {
+          id: 2,
+          rating: 2,
+          date: "2015-05-01T00:00:00.000Z"
+        }
+      ]
+    }
+  };
+
+  deepEqual(buildJson, expectedJson);
+});
 
 module(title(adapter, 'FactoryGuy#buildList custom'), inlineSetup(App, adapterType));
 


### PR DESCRIPTION
Currently factory-guy only supports embedding records using:

```
attrs: {
  reviews: {embedded: 'always'}
}
```
but Ember Data also allows you to embed records using:

```
attrs: {
  reviews: {deserialize: 'records'}
}
```

From [the API docs](http://emberjs.com/api/data/classes/DS.EmbeddedRecordsMixin.html#toc_using-embedded-records)

> The attrs option for a resource `{ embedded: 'always' }` is shorthand for: `{ serialize: 'records', deserialize: 'records' }`