### PR TITLE
Added failing test for `returns` with mockCreate

### DIFF
--- a/tests/acceptance/user-view-test.js
+++ b/tests/acceptance/user-view-test.js
@@ -58,10 +58,18 @@ test("Add a project to a user with mockCreate", function () {
 
     // Remember, this is for handling an exact match, if you did not care about
     // matching attributes, you could just do: TestHelper.mockCreate('project')
+
+    // USING BUILD
+    // let project = build('project');
+    // mockCreate('project').match({title: newProjectTitle}).returns({project});
+    // mockCreate('project').match({title: newProjectTitle}).returns({project: project});
+
+    // USING MAKE
     let project = make('project');
+    mockCreate('project').match({title: newProjectTitle}).returns({project: project.id});
+
     mockReload('project', project.get('id'));
     console.log('Project record ID returned in Test code:', project.get('id'));
-    mockCreate('project').match({title: newProjectTitle}).returns({model: project});
 
     /**
      Let's say that clicking this 'button:contains(Add New User)', triggers action in the

--- a/tests/acceptance/user-view-test.js
+++ b/tests/acceptance/user-view-test.js
@@ -1,4 +1,4 @@
-import { make, build, buildList, mockFind, mockCreate } from 'ember-data-factory-guy';
+import { make, build, buildList, mockFind, mockCreate, mockReload } from 'ember-data-factory-guy';
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | User View');
@@ -58,7 +58,10 @@ test("Add a project to a user with mockCreate", function () {
 
     // Remember, this is for handling an exact match, if you did not care about
     // matching attributes, you could just do: TestHelper.mockCreate('project')
-    mockCreate('project').match({title: newProjectTitle});
+    let project = make('project');
+    mockReload('project', project.get('id'));
+    console.log('Project record ID returned in Test code:', project.get('id'));
+    mockCreate('project').match({title: newProjectTitle}).returns({model: project});
 
     /**
      Let's say that clicking this 'button:contains(Add New User)', triggers action in the

--- a/tests/dummy/app/components/single-user.js
+++ b/tests/dummy/app/components/single-user.js
@@ -8,7 +8,10 @@ export default Ember.Component.extend({
     addProject: function (user) {
       let title = this.$('input.project-title').val();
       let store = this.get('controller.store');
-      this.get('store').createRecord('project', {title: title, user: user}).save();
+      this.get('store').createRecord('project', {title: title, user: user}).save().then((record) => {
+        console.log('Project record ID returned in App code:', record.get('id'));
+        record.reload();
+      });
     }
   }
 });


### PR DESCRIPTION
I'm seeing some weird behaviour with `returns` not working but not sure if it's because I'm doing something wrong.

Essentially in the acceptance test I do:

``` js
let project = make('project'); //project record has id 1
mockCreate('project').match({title: newProjectTitle}).returns({model: project})
```

yet in the application code that calls `createRecord` the record is a newly created one and not the one from the `returns`

``` js
this.get('store').createRecord('project', {title: title, user: user}).save()
.then((record) => {
  // project record has id 2
});
```

The consequence of this is that the `record.reload()` fails due to `mockReload` being passed the wrong record id in the test.

Am I doing something wrong here or is this a bug?