### PR TITLE
Tests for mockUpdate.match #216

### DIFF
--- a/addon/mocks/mock-create-request.js
+++ b/addon/mocks/mock-create-request.js
@@ -1,24 +1,17 @@
 import Ember from 'ember';
 import FactoryGuy from '../factory-guy';
-import MockRequest from './mock-request';
-import {isEquivalent} from '../utils/helper-functions';
-const { isPresent, isEmpty } = Ember;
+import MockRequest from './mock-request-match';
+const { isPresent } = Ember;
 
 export default class MockCreateRequest extends MockRequest {
 
   constructor(modelName) {
     super(modelName);
-    this.matchArgs = {};
     this.returnArgs = {};
   }
 
   getType() {
     return "POST";
-  }
-
-  match(matches) {
-    this.matchArgs = matches;
-    return this;
   }
 
   /**
@@ -35,48 +28,6 @@ export default class MockCreateRequest extends MockRequest {
   }
 
   /**
-   * This is tricky, but the main idea here is:
-   *
-   * #1 Take the keys they want to match and transform them to what the serialized
-   *  version would be ie. company => company_id
-   *
-   * #2 Take the matchArgs and turn them into a FactoryGuy payload class by
-   *  FactoryGuy.build(ing) them into a payload
-   *
-   * #3 Wrap the request data into a FactoryGuy payload class
-   *
-   * #4 Go though the keys from #1 and check that both the payloads from #2/#3 have the
-   * same values
-   *
-   * @param requestData
-   * @returns {boolean} true is no attributes to match or they all match
-   */
-  attributesMatch(requestData) {
-    if (isEmpty(Object.keys(this.matchArgs))) {
-      return true;
-    }
-
-    let builder = FactoryGuy.fixtureBuilder;
-
-    // transform they match keys
-    let matchCheckKeys = Object.keys(this.matchArgs).map((key)=> {
-      return builder.transformKey(this.modelName, key);
-    });
-
-    // build the match args into a JSONPayload class
-    let buildOpts = { serializeMode: true, transformKeys: true };
-    let expectedData = builder.convertForBuild(this.modelName, this.matchArgs, buildOpts);
-
-    // wrap request data in a JSONPayload class
-    builder.wrapPayload(this.modelName, requestData);
-
-    // success if all values match
-    return matchCheckKeys.map((key)=> {
-      return isEquivalent(expectedData.get(key), requestData.get(key));
-    }).every((value)=> value);
-  }
-
-  /**
    Unless the id is setup already in the return args, then setup a new id. 
    */
   modelId() {
@@ -86,16 +37,6 @@ export default class MockCreateRequest extends MockRequest {
       let definition = FactoryGuy.findModelDefinition(this.modelName);
       return definition.nextId();
     }
-  }
-
-  extraRequestMatches(settings) {
-    if (this.matchArgs) {
-      let requestData = JSON.parse(settings.data);
-      if (!this.attributesMatch(requestData)) {
-        return false;
-      }
-    }
-    return true;
   }
 
   /**

--- a/addon/mocks/mock-request-match.js
+++ b/addon/mocks/mock-request-match.js
@@ -1,0 +1,69 @@
+import Ember from 'ember';
+import FactoryGuy from '../factory-guy';
+import MockRequest from './mock-request';
+import {isEquivalent} from '../utils/helper-functions';
+const { isEmpty } = Ember;
+
+export default class MockRequestMatch extends MockRequest {
+  constructor(modelName, id) {
+    super(modelName);
+    this.matchArgs = {};
+  }
+
+  match(matches) {
+    this.matchArgs = matches;
+    return this;
+  }
+
+  extraRequestMatches(settings) {
+    if (this.matchArgs) {
+      let requestData = JSON.parse(settings.data);
+      if (!this.attributesMatch(requestData)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * This is tricky, but the main idea here is:
+   *
+   * #1 Take the keys they want to match and transform them to what the serialized
+   *  version would be ie. company => company_id
+   *
+   * #2 Take the matchArgs and turn them into a FactoryGuy payload class by
+   *  FactoryGuy.build(ing) them into a payload
+   *
+   * #3 Wrap the request data into a FactoryGuy payload class
+   *
+   * #4 Go though the keys from #1 and check that both the payloads from #2/#3 have the
+   * same values
+   *
+   * @param requestData
+   * @returns {boolean} true is no attributes to match or they all match
+   */
+  attributesMatch(requestData) {
+    if (isEmpty(Object.keys(this.matchArgs))) {
+      return true;
+    }
+
+    let builder = FactoryGuy.fixtureBuilder;
+
+    // transform they match keys
+    let matchCheckKeys = Object.keys(this.matchArgs).map((key)=> {
+      return builder.transformKey(this.modelName, key);
+    });
+
+    // build the match args into a JSONPayload class
+    let buildOpts = { serializeMode: true, transformKeys: true };
+    let expectedData = builder.convertForBuild(this.modelName, this.matchArgs, buildOpts);
+
+    // wrap request data in a JSONPayload class
+    builder.wrapPayload(this.modelName, requestData);
+
+    // success if all values match
+    return matchCheckKeys.map((key)=> {
+      return isEquivalent(expectedData.get(key), requestData.get(key));
+    }).every((value)=> value);
+  }
+};

--- a/addon/mocks/mock-update-request.js
+++ b/addon/mocks/mock-update-request.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import FactoryGuy from '../factory-guy';
-import MockRequest from './mock-request';
+import MockRequest from './mock-request-match';
 
 export default class MockUpdateRequest extends MockRequest {
 
@@ -64,7 +64,8 @@ export default class MockUpdateRequest extends MockRequest {
   getResponse() {
     this.responseJson = null;
     if (this.id) {
-      let json = Ember.$.extend({}, this.returnArgs, { id: this.id });
+      let args = Ember.$.extend({}, this.matchArgs, this.returnArgs);
+      let json = Ember.$.extend({}, args, { id: this.id });
       this.responseJson = FactoryGuy.fixtureBuilder.convertForBuild(this.modelName, json);
     }
     return super.getResponse();


### PR DESCRIPTION
Here's some tests for mockUpdate().match().

The tests pass and it works how I need in my own app's tests when I copy the methods match(), extraRequestMatches(), and attributesMatch() from mock-create-request.js to mock-update-request.js.

But you probably want something cleaner than a copy/paste job. Not sure if there would be any variation  for update. If not, maybe a 'mock-match-request' class with those methods which both create and update extend.