### PR TITLE
mockFind does not return a failed response

### DIFF
--- a/tests/unit/shared-factory-guy-test-helper-tests.js
+++ b/tests/unit/shared-factory-guy-test-helper-tests.js
@@ -43,7 +43,7 @@ SharedBehavior.mockFindCommonTests = function() {
 
       equal(mock.get('catName'), 'Cat 1');
       equal(mock.get('catFriend'), 'Friend 1');
-      
+
       FactoryGuy.store.find('cat', mock.get('id')).then(function(cat) {
         equal(cat.get('name'), 'Cat 1');
         equal(cat.get('friend'), 'Friend 1');
@@ -118,6 +118,24 @@ SharedBehavior.mockFindCommonTests = function() {
         ok(profile.get('description') === 'dude');
         done();
       });
+    });
+  });
+
+  test("failure with fails method", function(assert) {
+    Ember.run(()=> {
+      let done = assert.async();
+
+      let profile = make('profile');
+      let profileId = profile.get('id');
+      let mock = mockFind('profile').fails();
+
+      FactoryGuy.store.findRecord('profile', profileId)
+        .catch(()=> {
+            equal(mock.timesCalled, 1);
+            ok(true);
+            done();
+          }
+        );
     });
   });
 


### PR DESCRIPTION
```
not ok 368 PhantomJS 2.1 - DS.RESTAdapter/JSONSerializer | #mockFind: failure with fails method
    ---
        actual: >
            false
        expected: >
            true
        stack: >
            http://localhost:7357/assets/test-support.js:4147:17
            exception@http://localhost:7357/assets/vendor.js:59253:9
            onerrorDefault@http://localhost:7357/assets/vendor.js:51230:33
            trigger@http://localhost:7357/assets/vendor.js:73618:19
            http://localhost:7357/assets/vendor.js:74869:40
            invoke@http://localhost:7357/assets/vendor.js:19475:20
            flush@http://localhost:7357/assets/vendor.js:19539:17
            flush@http://localhost:7357/assets/vendor.js:19347:22
            end@http://localhost:7357/assets/vendor.js:19702:30
            run@http://localhost:7357/assets/vendor.js:19824:21
            join@http://localhost:7357/assets/vendor.js:19844:30
            join@http://localhost:7357/assets/vendor.js:40323:33
            error@http://localhost:7357/assets/vendor.js:102546:39
            fire@http://localhost:7357/assets/vendor.js:7906:36
            fireWith@http://localhost:7357/assets/vendor.js:8036:11
            done@http://localhost:7357/assets/vendor.js:13478:24
            http://localhost:7357/assets/vendor.js:13842:17
        message: >
            Error: Ember Data Request GET /profiles/1 returned a 404
            Payload (text/html; charset=utf-8)
            Not found: /profiles/1/tests/index.html?hidepassed
        Log: |
    ...
```