### PR TITLE
withSomeParams modifier for mockGetRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1305,6 +1305,7 @@ Usage:
     - returns( models / json / ids )
    - Takes modifier methods for matching the query params
     - withParams( object )
+    - withSomeParams( object )
   - Sample acceptance tests using mockQuery: [user-search-test.js](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/acceptance/user-search-test.js)
 
 Usage: 
@@ -1346,7 +1347,6 @@ Usage:
 ```
 
   - with returns( ids )
-
 ```js
   // Create list of models
   let users = buildList('user', 2, 'with_hats');
@@ -1358,6 +1358,33 @@ Usage:
     // models will be one model and it will be user1
   });
 
+```
+
+  - withParams() / withSomeParams()
+```js
+  // Create list of models
+  let users = buildList('user', 2, 'with_hats');
+  let user1 = users.get(0);
+  
+  mock = mockQuery('user').returns({ids: [user1.id]});
+  
+  mock.withParams({name:'Bob', age: 10})
+  
+  // When using 'withParams' modifier, params hash must match exactly
+  store.query('user', {name:'Bob', age: 10}}).then(function(models) {
+    // models will be one model and it will be user1
+  });
+
+  // The following call will not be caught by the mock
+  store.query('user', {name:'Bob', age: 10, hair: 'brown'}})
+
+  // 'withSomeParams' is designed to catch requests by partial match
+  // It has precedence over strict params matching once applied
+  mock.withSomeParams({name:'Bob'})
+  
+  // Now both requests will be intercepted
+  store.query('user', {name:'Bob', age: 10}})
+  store.query('user', {name:'Bob', age: 10, hair: 'brown'}})
 ```
 
 ##### mockQueryRecord

--- a/addon/mocks/mock-get-request.js
+++ b/addon/mocks/mock-get-request.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import FactoryGuy from '../factory-guy';
 import Model from 'ember-data/model';
 import MockRequest from './mock-request';
-import { isEquivalent } from '../utils/helper-functions';
+import { isEquivalent, isPartOf } from '../utils/helper-functions';
 const assign = Ember.assign || Ember.merge;
 
 class MockGetRequest extends MockRequest {
@@ -125,12 +125,28 @@ class MockGetRequest extends MockRequest {
     return this;
   }
 
-  paramsMatch(settings) {
-    if (Ember.$.isEmptyObject(this.queryParams)) {
-      return true;
-    }
-    return isEquivalent(this.queryParams, settings.data);
+  withSomeParams(someQueryParams) {
+    this.someQueryParams = someQueryParams;
+    return this;
   }
+
+  // paramsMatch(settings) {
+  //   if (Ember.$.isEmptyObject(this.queryParams)) {
+  //     return true;
+  //   }
+  //   return isEquivalent(this.queryParams, settings.data);
+  // }
+
+  paramsMatch(settings) {
+    if (!Ember.$.isEmptyObject(this.queryParams)) {
+      return isEquivalent(this.queryParams, settings.data);
+    }
+    if (!Ember.$.isEmptyObject(this.someQueryParams)) {
+      return isPartOf(settings.data, this.someQueryParams);
+    }
+    return true;
+  }
+
 
   extraRequestMatches(settings) {
     return this.paramsMatch(settings);

--- a/addon/mocks/mock-get-request.js
+++ b/addon/mocks/mock-get-request.js
@@ -130,19 +130,12 @@ class MockGetRequest extends MockRequest {
     return this;
   }
 
-  // paramsMatch(settings) {
-  //   if (Ember.$.isEmptyObject(this.queryParams)) {
-  //     return true;
-  //   }
-  //   return isEquivalent(this.queryParams, settings.data);
-  // }
-
   paramsMatch(settings) {
-    if (!Ember.$.isEmptyObject(this.queryParams)) {
-      return isEquivalent(this.queryParams, settings.data);
-    }
     if (!Ember.$.isEmptyObject(this.someQueryParams)) {
       return isPartOf(settings.data, this.someQueryParams);
+    }
+    if (!Ember.$.isEmptyObject(this.queryParams)) {
+      return isEquivalent(this.queryParams, settings.data);
     }
     return true;
   }

--- a/addon/utils/helper-functions.js
+++ b/addon/utils/helper-functions.js
@@ -18,6 +18,12 @@ export function isEquivalent(a, b) {
   }
 }
 
+export function isPartOf(object, part) {
+  return Object.keys(part).every(function(key) {
+    return isEquivalent(object[key], part[key]);
+  });
+}
+
 function arrayIsEquivalent(arrayA, arrayB) {
   if (arrayA.length !== arrayB.length) {
     return false;

--- a/tests/unit/shared-factory-guy-test-helper-tests.js
+++ b/tests/unit/shared-factory-guy-test-helper-tests.js
@@ -825,6 +825,27 @@ SharedBehavior.mockQueryTests = function() {
     });
   });
 
+  test("mock query with withSomeParams captures the query even if it contains additional params", function(assert) {
+    Ember.run(()=> {
+      let done = assert.async();
+
+      let companies1 = makeList('company', 2);
+      let companies2 = makeList('company', 2);
+
+      let matchQueryHandler = mockQuery('company').withSomeParams({ name: 'Dude' }).returns({ models: companies1 });
+      let allQueryHandler = mockQuery('company').returns({ models: companies2 });
+ 
+      FactoryGuy.store.query('company', { name: 'Dude', page: 1 }).then(function(companies) {
+        equal(A(companies).mapBy('id') + '', A(companies1).mapBy('id') + '');
+
+        FactoryGuy.store.query('company', { name: 'Other', page: 1 }).then(function(companies) {
+          equal(A(companies).mapBy('id') + '', A(companies2).mapBy('id') + '');
+          done();
+        });
+      });
+    });
+  });
+
 };
 
 SharedBehavior.mockQueryMetaTests = function(App, adapter, serializerType) {

--- a/tests/unit/utils/helper-functions-test.js
+++ b/tests/unit/utils/helper-functions-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { isEquivalent } from 'ember-data-factory-guy/utils/helper-functions';
+import { isEquivalent, isPartOf } from 'ember-data-factory-guy/utils/helper-functions';
 
 module('isEquivalent | Helper Function');
 
@@ -100,4 +100,18 @@ test('#isEquivalent with deeply nested objects', function(assert) {
   }), 'returns true if object key-value pairs are equivalent' );
 
   assert.ok( !isEquivalent(nestedZoey, nestedTomster), 'returns false if object key-value pairs are not equivalent' );
+});
+
+test('#isPartOf', function(assert) {
+  assert.ok( isPartOf(tomster, { name: 'Tomster' } ), 
+    'returns true if the first object contains all key-value pairs from the second object' );
+
+  assert.ok( isPartOf(tomster, tomster), 
+    'returns true if the first object is the same as the second object' );
+
+  assert.ok( isPartOf(tomster, {}), 
+    'returns true if the second object is empty' );
+
+  assert.notOk( isPartOf(tomster, { name: 'Tomster', number: 1 } ), 
+    'returns false if the first object does not contains key-value pairs from the second object' );
 });


### PR DESCRIPTION
This PR introduces new functionality to match by some params. Here's the excerpt from documentation additions:
```js
  // Create list of models
  let users = buildList('user', 2, 'with_hats');
  let user1 = users.get(0);
  
  mock = mockQuery('user').returns({ids: [user1.id]});
  
  mock.withParams({name:'Bob', age: 10})
  
  // When using 'withParams' modifier, params hash must match exactly
  store.query('user', {name:'Bob', age: 10}}).then(function(models) {
    // models will be one model and it will be user1
  });

  // The following call will not be caught by the mock
  store.query('user', {name:'Bob', age: 10, hair: 'brown'}})

  // 'withSomeParams' is designed to catch requests by partial match
  // It has precedence over strict params matching once applied
  mock.withSomeParams({name:'Bob'})
  
  // Now both requests will be intercepted
  store.query('user', {name:'Bob', age: 10}})
  store.query('user', {name:'Bob', age: 10, hair: 'brown'}})
```

Probably both `withParams` and `withSomeParams` calls might need to clear opposite object to be able to switch between behaviors in flight.

kudos to @ryedeer 👍 👍 👍 