### PR TITLE
disable(), enable(), and destroy() methods for mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1111,6 +1111,13 @@ test("Using FactoryGuy.cacheOnlyMode with except", function() {
     });
   ```
 
+- Use method `disable()` to temporarily disable the mock. You can re-enable
+the disabled mock using `enable()`.
+
+- Use method `destroy()` to completely remove the mockjax handler for the mock.
+The `isDestroyed` property is set to `true` when the mock is destroyed.
+
+
 ##### setup and teardown
   - Use ```mockSetup()``` in test setup/beforeEach
    - set logging options here:

--- a/addon/mocks/mock-request.js
+++ b/addon/mocks/mock-request.js
@@ -11,6 +11,8 @@ export default class {
     this.responseHeaders = {};
     this.responseJson = null;
     this.errorResponse = null;
+    this.isDisabled = false;
+    this.isDestroyed = false;
     this.handler = this.setupHandler();
     this.timesCalled = 0;
   }
@@ -96,6 +98,9 @@ export default class {
   //////////////  common handler for all requests ////////////
   setupHandler() {
     let handler = function(settings) {
+      if (this.isDisabled) {
+        return false;
+      }
       if (!this.basicRequestMatches(settings)) {
         return false;
       }
@@ -110,8 +115,21 @@ export default class {
       return response;
     }.bind(this);
 
-    Ember.$.mockjax(handler);
+    this.mockId = Ember.$.mockjax(handler);
 
     return handler;
+  }
+
+  disable() {
+    this.isDisabled = true;
+  }
+
+  enable() {
+    this.isDisabled = false;
+  }
+
+  destroy() {
+    Ember.$.mockjax.clear(this.mockId);
+    this.isDestroyed = true;
   }
 }


### PR DESCRIPTION
These methods can be used to temporarily disable and re-enable the mock or to completely destroy the mockjax handler.

The excerpt from the docs:
> 
- Use method `disable()` to temporarily disable the mock. You can re-enable
the disabled mock using `enable()`.
>
- Use method `destroy()` to completely remove the mockjax handler for the mock.
The `isDestroyed` property is set to `true` when the mock is destroyed.
