### PR TITLE
es6 args destructuring removed from public api on mocks

### DIFF
--- a/addon/mocks/mock-request.js
+++ b/addon/mocks/mock-request.js
@@ -32,8 +32,8 @@ export default class {
     assign(this.responseHeaders, headers);
   }
 
-  succeeds({ status = 200 }={}) {
-    this.status = status;
+  succeeds(opts = {}) {
+    this.status = opts.status || 200;
     this.errorResponse = null;
     return this;
   }
@@ -42,7 +42,10 @@ export default class {
     return !!status.toString().match(/^([345]\d{2})/);
   }
 
-  fails({ status = 500, response = null, convertErrors = true }={}) {
+  fails(opts = {}) {
+    var convertErrors = opts.hasOwnProperty('convertErrors') ? opts.convertErrors : true;
+    var status = opts.status || 500;
+    var response = opts.response || null;
     Ember.assert(`[ember-data-factory-guy] 'fails' method status code must be 3XX, 4XX or 5XX,
         you are using: ${status}`, this.isErrorStatus(status));
 

--- a/addon/mocks/mock-update-request.js
+++ b/addon/mocks/mock-update-request.js
@@ -51,18 +51,6 @@ export default class MockUpdateRequest extends AttributeMatcher(MockRequest) {
   }
 
   /**
-   Not sure why the update errors don't need conversion ?? puzzled
-  
-   @param status
-   @param response
-   @param convertErrors
-   @returns {*}
-   */
-  fails({ status= 500, response= null, convertErrors= false }={}) {
-    return super.fails({ status, response, convertErrors });
-  }
-
-  /**
    Adapters freak out if update payload is non empty response with no id.
    So, if there is no id specified for this update => return null
 

--- a/tests/unit/shared-factory-guy-test-helper-tests.js
+++ b/tests/unit/shared-factory-guy-test-helper-tests.js
@@ -1736,7 +1736,8 @@ SharedBehavior.mockUpdateWithErrorMessages = function(App, adapter, serializerTy
 
       mockUpdate(profile).fails({
         status: 400,
-        response: { errors: { description: 'invalid data' } }
+        response: { errors: { description: ['invalid data'] } },
+        convertErrors: false
       });
 
       profile.set('description', 'new desc');


### PR DESCRIPTION
This PR addresses #226 

Even though the issue is fixed, there are still questions on whether `convertErrors` should be adapter specific. For example, someone using json-api, would expect errors as per spec:
http://jsonapi.org/examples/#error-objects-multiple-errors
When with `DS.RESTAdapter` it's just `{errors: {field: ['error 1', 'error 2']}}`

Should we remove that option at all and do the conversion implicitly depending on what adapter is in use?