### PR TITLE
Use Array.includes instead of deprecated contains if possible

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -522,7 +522,8 @@ class FactoryGuy {
       let adapter = findAdapter(name);
       let shouldCache = ()=> {
         if (Ember.isPresent(except)) {
-          return (Ember.A(except).contains(name));
+          const array = Ember.A(except);
+          return array.includes ? array.includes(name) : array.contains(name);
         }
         return false;
       };

--- a/addon/mocks/mock-get-request.js
+++ b/addon/mocks/mock-get-request.js
@@ -45,9 +45,12 @@ class MockGetRequest extends MockRequest {
                 you passed these keys: ${responseKeys}`, responseKeys.length <= 1);
 
     const [ responseKey ] = responseKeys;
+
+    const array = Ember.A(this.validReturnsKeys);
+
     Ember.assert(`[ember-data-factory-guy] You passed an invalid key for 'returns' function.
       Valid keys are ${this.validReturnsKeys}. You used this key: ${responseKey}`,
-      Ember.A(this.validReturnsKeys).contains(responseKey));
+      array.includes ? array.includes(responseKey) : array.contains(responseKey));
 
     return responseKey;
   }

--- a/addon/payload/base-payload.js
+++ b/addon/payload/base-payload.js
@@ -45,7 +45,10 @@ export default class {
   add(more) {
     this.converter.included = this.json;
     Ember.A(Object.getOwnPropertyNames(more))
-      .reject(key=> Ember.A(this.proxyMethods).contains(key))
+      .reject(key=> {
+        const array = Ember.A(this.proxyMethods)
+        return array.includes ? array.includes(key) : array.contains(key);
+      })
       .forEach(key=> {
         if (Ember.typeOf(more[key]) === "array") {
           more[key].forEach(data=> this.converter.addToIncluded(data, key));

--- a/addon/payload/rest-payload.js
+++ b/addon/payload/rest-payload.js
@@ -11,7 +11,10 @@ export default class extends BasePayload {
 
   includeKeys() {
     let keys = Ember.A(Object.keys(this.json)).reject(key => this.payloadKey === key);
-    return Ember.A(keys).reject(key=> Ember.A(this.proxyMethods).contains(key)) || [];
+    return Ember.A(keys).reject(key=> {
+      const array = Ember.A(this.proxyMethods);
+      return array.includes ? array.includes(key) : array.contains(key);
+    }) || [];
   }
 
   getInclude(modelType) {


### PR DESCRIPTION
- Ember 2.8 deprecated Ember.Array.contains
- Use Ember.array.includes if available