### PR TITLE
addIncludedArray() replacing payload data with included

### DIFF
--- a/addon/converter/rest-fixture-converter.js
+++ b/addon/converter/rest-fixture-converter.js
@@ -53,7 +53,11 @@ export default class extends JSONFixtureConverter {
    */
   addIncludedArray(payload) {
     Object.keys(this.included).forEach((key)=> {
-      payload[key] = this.included[key];
+      if (!payload[key]) {
+        payload[key] = this.included[key];
+      } else {
+      	Array.prototype.push.apply(payload[key], this.included[key]);
+      }
     });
   }
 


### PR DESCRIPTION
I have a model 'department', which is hierarchal. Each department can have a parent. So the department model has a relationship with its own model type 'department'.

In my tests, I have a trait called 'parent' and one called 'primary'.

```
FactoryGuy.define('department', {
    traits: {
        primary: {
            name: 'Primary Department',
            parent: FactoryGuy.belongsTo('department', 'parent'),
        },
        parent: {
            name: 'Parent Department',
            parent: null
        }
    }
//...
});
```

When I use `buildList()` and include the 'primary' trait, the result I get back contains only the 'parent' model.

Stepping through, I found this is because addIncludedArray() in rest-fixture-converter is setting `payload[key] = this.included[key];`. Since the key 'department' is present in 'included', it replaces everything that in the payload when I want it to add it to the payload.

I wasn't sure where the best place to add this to tests would be, but I can put one together if you let me know.
