### PR TITLE
Add support for using factory-guy in other environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,6 +812,10 @@ You would use this to make models like:
 
 - You can set up scenarios for you app that use all your factories from tests
 - In config/environment.js place a flag => factoryGuy: true
+- NOTE: Do not set the flag => factoryGuy: true in the `test` environment. Factories are enabled
+  by default for the `test` environment and setting the flag tells factory-guy to load the app/scenarios
+  files which are not needed for using factory-guy in testing. This will result in errors being generated if
+  the app/scenarios files do not exist.
   ```js
     // file: config/environment.js
     if (environment === 'development') {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Contents:
   - [Associations](https://github.com/danielspaniel/ember-data-factory-guy#associations)
   - [Extending Other Definitions](https://github.com/danielspaniel/ember-data-factory-guy#extending-other-definitions)
   - [Callbacks / Transient Attributes](https://github.com/danielspaniel/ember-data-factory-guy#callbacks)
-  - [Using in Development](https://github.com/danielspaniel/ember-data-factory-guy#using-in-development)
+  - [Using in Development, Production or other environments](https://github.com/danielspaniel/ember-data-factory-guy#using-in-other-environments)
   - [Ember Data Model Fragments](https://github.com/danielspaniel/ember-data-factory-guy#ember-data-model-fragments)
   - [Creating Factories in Addons](https://github.com/danielspaniel/ember-data-factory-guy#creating-factories-in-addons)
   - [Ember Django Adapter](https://github.com/danielspaniel/ember-data-factory-guy#ember-django-adapter)
@@ -49,7 +49,7 @@ ChangeLog: ( Notes about what has changed in each version )
   - [Release Notes](https://github.com/danielspaniel/ember-data-factory-guy/releases)
 
 ### Installation
-   
+
  - ```ember install ember-data-factory-guy``` ( ember-data-1.13.5+ )
  - ```ember install ember-data-factory-guy@1.13.2``` ( ember-data-1.13.0 + )
  - ```ember install ember-data-factory-guy@1.1.2``` ( ember-data-1.0.0-beta.19.1 )
@@ -102,7 +102,7 @@ In the following examples, assume the models look like this:
  - Create factory files in the tests/factories directory.
  - Can use generator to create the outline of a factory file:
   ```ember g factory user``` This will create a file named user.js in the tests/factories directory.
- 
+
 
 ##### Standard models
 
@@ -129,7 +129,7 @@ FactoryGuy.define('user', {
 
 ```
 
-- If you are using an attribute named 'type' and this is not a polymorphic model, use the option 
+- If you are using an attribute named 'type' and this is not a polymorphic model, use the option
   ```polymorphic: false``` in your definition
 ```js
 // file: tests/factories/cat.js
@@ -147,7 +147,7 @@ FactoryGuy.define('cat', {
 ##### Polymorphic models
 
  - Define each polymorphic model in it's own typed definition
- - The attribute named 'type' is used to hold the model name 
+ - The attribute named 'type' is used to hold the model name
  - May want to extend parent factory here
    - See [Extending Other Definitions](https://github.com/danielspaniel/ember-data-factory-guy#extending-other-definitions)
 
@@ -808,13 +808,21 @@ You would use this to make models like:
 
 ```
 
-### Using in Development
+### Using in Other Environments
 
 - You can set up scenarios for you app that use all your factories from tests
 - In config/environment.js place a flag => factoryGuy: true
   ```js
     // file: config/environment.js
     if (environment === 'development') {
+      ENV.factoryGuy = true;
+      ENV.locationType = 'auto';
+      ENV.rootURL = '/';
+    }
+
+    or
+
+    if (environment === 'production') {
       ENV.factoryGuy = true;
       ENV.locationType = 'auto';
       ENV.rootURL = '/';
@@ -1740,7 +1748,7 @@ person.save(); // will succeed
 3. Can pass in random attributes to help build the fixture
   - sorta like transient attributes but these don't get passed to afterMake
   - hence can be used in build/buildList as well
-  
+
 Let's say you have a model and a factory like this:
 
 ```javascript
@@ -1756,9 +1764,9 @@ Let's say you have a model and a factory like this:
 
  // tests/factories/dog.js
  import FactoryGuy from 'ember-data-factory-guy';
- 
+
  const defaultVolume = "Normal";
- 
+
  FactoryGuy.define('dog', {
    default: {
      dogNumber: (f)=> `Dog${f.id}`,
@@ -1766,13 +1774,13 @@ Let's say you have a model and a factory like this:
    }
  });
 ```
- 
+
 Then to build the fixture:
 
 ```javascript
   let volume = 'Soft';
   let dog2 = build('dog', { volume });
-  
-  dog2.get('sound'); //=> `Soft Woof` 
-```  
-  
+
+  dog2.get('sound'); //=> `Soft Woof`
+```
+

--- a/addon/utils/load-scenarios.js
+++ b/addon/utils/load-scenarios.js
@@ -3,15 +3,15 @@ import {requireFiles} from './helper-functions';
 
 const scenarioFileRegExp = new RegExp('/scenarios/main$');
 /**
- * There is only one scenario file that is important here. 
+ * There is only one scenario file that is important here.
  * And that is: scenarios/main.js file.
- * 
- * This file dictates what the scenario will be, since from 
+ *
+ * This file dictates what the scenario will be, since from
  * there you can include other scenarios, and compose whatever
  * grand scheme you have in mind
- * 
- * NOTE: container.owner.resolveRegistration('config:environment') works as well  
- * 
+ *
+ * NOTE: container.owner.resolveRegistration('config:environment') works as well
+ *
  * @param container
  */
 export default function (container) {
@@ -19,10 +19,10 @@ export default function (container) {
 
   if (config.factoryGuy) {
     let [Scenario] = requireFiles(scenarioFileRegExp);
-    Ember.assert(`[ember-data-factory-guy] No app/scenarios/main.js file was found. 
-      If you have factoryGuy set to true in config/environment.js file, 
-      then you should setup a file app/scenarios/main.js to control what data will 
-      be like in the development application.`, Scenario);
+    Ember.assert(`[ember-data-factory-guy] No app/scenarios/main.js file was found.
+      If you have factoryGuy set to true in config/environment.js file,
+      then you should setup a file app/scenarios/main.js to control what data will
+      be like in the application.`, Scenario);
     (new Scenario['default']()).run();
   }
 }

--- a/index.js
+++ b/index.js
@@ -26,10 +26,10 @@ module.exports = {
     this.parentConfig = config;
     return config;
   },
-  
+
   includeFactoryGuyFactories: function() {
     var config = this.parentConfig;
-    return config.environment === 'development' && config.factoryGuy;
+    return config.factoryGuy;
   },
 
   treeForApp: function(appTree) {


### PR DESCRIPTION
Closes: https://github.com/danielspaniel/ember-data-factory-guy/issues/254

CHANGELOG:
**Updated** index.js to support using factory-guy in other environments
**Updated** README to show configuration needed for using factory-guy in other environments


DESCRIPTION:
This PR adds support for using factory-guy in other environments to the base cases of `development` and `test`.

The user just needs to add:

```
// file: config/environment.js
ENV.factoryGuy = true;
``` 

to the environments in which factory-guy is desired.

By default, the test environment is still enabled but now a user can turn it off by specifying:

```
// file: config/environment.js
if (environment === 'test') {
  ENV.factoryGuy = false;
  ...
}
```
