### PR TITLE
Fix URLs for query and queryRecord

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -503,9 +503,9 @@ class FactoryGuy {
    @param {String} id
    @return {String} url
    */
-  buildURL(modelName, id = null, requestType) {
+  buildURL(modelName, id = null, requestType, query) {
     const adapter = this.store.adapterFor(modelName);
-    return adapter.buildURL(modelName, id, null, requestType);
+    return adapter.buildURL(modelName, id, null, requestType, query);
   }
 
   /**

--- a/addon/mocks/mock-query-record-request.js
+++ b/addon/mocks/mock-query-record-request.js
@@ -14,4 +14,8 @@ export default class MockQueryRecordRequest extends MockQueryRequest {
     this.setResponseJson(FactoryGuy.fixtureBuilder.convertForBuild(modelName, null));
     this.setValidReturnsKeys(['model','json','id','headers']);
   }
+
+  getUrl() {
+    return FactoryGuy.buildURL(this.modelName, null, 'queryRecord', this.get('query'));
+  }
 }

--- a/addon/mocks/mock-query-record-request.js
+++ b/addon/mocks/mock-query-record-request.js
@@ -16,6 +16,6 @@ export default class MockQueryRecordRequest extends MockQueryRequest {
   }
 
   getUrl() {
-    return FactoryGuy.buildURL(this.modelName, null, 'queryRecord', this.get('query'));
+    return FactoryGuy.buildURL(this.modelName, null, 'queryRecord', this.queryParams);
   }
 }

--- a/addon/mocks/mock-query-request.js
+++ b/addon/mocks/mock-query-request.js
@@ -10,4 +10,7 @@ export default class MockQueryRequest extends MockGetRequest {
     this.queryParams = queryParams;
   }
 
+  getUrl() {
+    return FactoryGuy.buildURL(this.modelName, null, 'query', this.get('query'));
+  }
 }

--- a/addon/mocks/mock-query-request.js
+++ b/addon/mocks/mock-query-request.js
@@ -11,6 +11,6 @@ export default class MockQueryRequest extends MockGetRequest {
   }
 
   getUrl() {
-    return FactoryGuy.buildURL(this.modelName, null, 'query', this.get('query'));
+    return FactoryGuy.buildURL(this.modelName, null, 'query', this.queryParams);
   }
 }

--- a/tests/unit/shared-factory-guy-test-helper-tests.js
+++ b/tests/unit/shared-factory-guy-test-helper-tests.js
@@ -909,7 +909,7 @@ SharedBehavior.mockQueryRecordTests = function() {
 
   test("when returning no result", function(assert) {
     var done = assert.async();
-    mockQueryRecord('user');
+    mockQueryRecord('user', {});
     FactoryGuy.store.queryRecord('user', {})
       .then(()=> {
         ok(true);
@@ -919,7 +919,7 @@ SharedBehavior.mockQueryRecordTests = function() {
 
   test("with no parameters matches queryRequest with any parameters", function(assert) {
     var done = assert.async();
-    mockQueryRecord('user').returns({ json: build('user') });
+    mockQueryRecord('user', { name: 'Bob' }).returns({ json: build('user') });
     FactoryGuy.store.queryRecord('user', { name: 'Bob' })
       .then(()=> {
         ok(true);


### PR DESCRIPTION
Currently, the URLs generated from mockQuery and mockQueryRecord don't singularize/pluralize appropriately, and they don't include the query hash that's passed in. This fixes that, so the requests are actually mocked.