### PR TITLE
Fix `Cannot read property '_super' of undefined` with Ember 2.10.0

### DIFF
--- a/addon/converter/fixture-converter.js
+++ b/addon/converter/fixture-converter.js
@@ -15,7 +15,7 @@ import Ember from 'ember';
  If there are associations in the base fixture, they will be added to the
  new fixture as 'side loaded' elements, even if they are another json payload
  built whith the build/buildList methods.
- 
+
  @param {DS.Store} store
  @param {Object} options
  transformKeys tranform keys and values in fixture if true
@@ -134,7 +134,7 @@ export default class {
           attrName = attrOptions;
         }
       }
-      return attrName || keyFn(attribute, kind);
+      return attrName || keyFn.call(this, attribute, kind);
     });
   }
 


### PR DESCRIPTION
This should fix https://github.com/danielspaniel/ember-data-factory-guy/issues/260

TODO:

 * [x] Verify that this does indeed fix the issue
 * [ ] Write a test
 * [x] Figure out why this worked in `Ember 2.9` and not `Ember 2.10`