### PR TITLE
Allow mockCreate/mockUpdate to receive a matching function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1483,12 +1483,14 @@ Usage:
 ##### mockCreate
 
   - Use chainable methods to build the response
-    - match
-      - Attributes that must be in request json
+    - match: takes a hash with attributes or a matching function
+      1. attributes that must be in request json
         - These will be added to the response json automatically, so
           you don't need to include them in the returns hash.
         - If you match on a belongsTo association, you don't have to include that in
-          the returns hash either ( same idea ).
+          the returns hash either ( same idea )
+      1. a function that can be used to perform an arbitrary match against the request
+          json, returning `true` if there is a match, `false` otherwise.
     - returns
       - Attributes ( including relationships ) to include in response json
   - Need to wrap tests using mockCreate with: Ember.run(function() { 'your test' })
@@ -1527,6 +1529,9 @@ Usage:
   // Match all attributes
   mockCreate('project').match({name: "Moo", user: user});
 
+  // Match using a function that checks that the request's top level attribute "name" equals 'Moo'
+  mockCreate('project').match(requestData => requestData.name === 'Moo');
+
   // Exactly matching attributes, and returning extra attributes
   mockCreate('project')
     .match({name: "Moo", user: user})
@@ -1563,8 +1568,10 @@ Usage:
   - mockUpdate(modelType, id)
     - Two arguments: modelType ( like 'profile' ) , and the profile id that will updated
   - Use chainable methods to help build response:
-    - match
-      - Attributes with values that must be present on the model you are updating
+    - match: takes a hash with attributes or a matching function
+      1. attributes with values that must be present on the model you are updating
+      1. a function that can be used to perform an arbitrary match against the request
+        json, returning `true` if there is a match, `false` otherwise.
     - returns
       - Attributes ( including relationships ) to include in response json
   - Need to wrap tests using mockUpdate with: Ember.run(function() { 'your test' })
@@ -1605,6 +1612,12 @@ Usage:
   profile.set('name', "woo");
   let mock = mockUpdate(profile).match({name: "moo"});
   profile.save();  // will not be mocked since the mock you set says the name must be "woo"
+
+  // using match() method to specify a matching function
+  let profile = make('profile');
+  profile.set('name', "woo");
+  let mock = mockUpdate(profile).match(requestData => requestData.name === "moo");
+  profile.save();  // will not be mocked since the mock you set requires the request's top level attribute "name" to equal "moo"
 
   // either set the name to "moo" which will now be mocked correctly
   profile.set('name', "moo");

--- a/addon/mocks/attribute-matcher.js
+++ b/addon/mocks/attribute-matcher.js
@@ -31,8 +31,10 @@ const AttributeMatcher = (superclass) => class extends superclass {
   extraRequestMatches(settings) {
     if (this.matchArgs) {
       let requestData = JSON.parse(settings.data);
-      if (!this.attributesMatch(requestData)) {
-        return false;
+      if (typeof this.matchArgs === 'function') {
+        return this.matchArgs(requestData);
+      } else {
+        return this.attributesMatch(requestData);
       }
     }
     return true;

--- a/tests/unit/shared-factory-guy-test-helper-tests.js
+++ b/tests/unit/shared-factory-guy-test-helper-tests.js
@@ -1098,6 +1098,44 @@ SharedBehavior.mockCreateTests = function() {
     });
   });
 
+  test("match can take a function - if it returns true it registers a match", function(assert) {
+    assert.expect(2);
+    Ember.run(() => {
+      let done = assert.async();
+
+      let mock = mockCreate('profile');
+
+      mock.match(function(/*requestData*/) {
+        ok(true, 'matching function is called');
+        return true;
+      });
+
+      FactoryGuy.store.createRecord('profile').save().then(function(/*profile*/) {
+        equal(mock.timesCalled, 1);
+        done();
+      });
+    });
+  });
+
+  test("match can take a function - if it returns false it does not register a match", function(assert) {
+    assert.expect(2);
+    Ember.run(() => {
+      let done = assert.async();
+
+      let mock = mockCreate('profile');
+
+      mock.match(function(/*requestData*/) {
+        ok(true, 'matching function is called');
+        return false;
+      });
+
+      FactoryGuy.store.createRecord('profile').save().catch(() => {
+        equal(mock.timesCalled, 0);
+        done();
+      });
+    });
+  });
+
   test("match some attributes", function(assert) {
     Ember.run(()=> {
       let done = assert.async();
@@ -1570,6 +1608,47 @@ SharedBehavior.mockUpdateTests = function() {
     });
   });
 
+  test("match can take a function - if it returns true it registers a match", function(assert) {
+    assert.expect(2);
+    Ember.run(() => {
+      let done = assert.async();
+      let customDescription = "special description";
+      let profile = make('profile');
+
+      let updateMock = mockUpdate(profile);
+
+      updateMock.match(function(/*requestData*/) {
+        ok(true, 'matching function is called');
+        return true;
+      });
+      profile.set('description', customDescription);
+      profile.save().then(function(/*profile*/) {
+        equal(updateMock.timesCalled, 1);
+        done();
+      });
+    });
+  });
+
+  test("match can take a function - if it returns false it does not register a match", function(assert) {
+    assert.expect(2);
+    Ember.run(() => {
+      let done = assert.async();
+      let customDescription = "special description";
+      let profile = make('profile');
+
+      let updateMock = mockUpdate(profile);
+
+      updateMock.match(function(/*requestData*/) {
+        ok(true, 'matching function is called');
+        return false;
+      });
+      profile.set('description', customDescription);
+      profile.save().catch(() => {
+        equal(updateMock.timesCalled, 0);
+        done();
+      });
+    });
+  });
   test("match some attributes", function(assert) {
     Ember.run(()=> {
       let done = assert.async();


### PR DESCRIPTION
**tl;dr** Allow `match` to accept a function or attribute(s) to determine whether a create or update matched.

The function passed to `match` is given the `requestData` and can perform bespoke logic to determine whether a request matched or not. If the function returns `true` then a match is recorded, otherwise it is not.

We have a use-case where we're updating a complex, nested model called `Parent`. `Parent` hasMany `Child` relationships, each of which has multiple attributes. We're mocking an update to `Parent` but what we really care about is one change to an attribute of `Child`, let's say `description`. Using the existing `match` function we would need to pass in the entire child structure, which is quite unwieldy. By allowing `match` to receive a function the responsibility of determining whether a match was made belongs to the test, e.g.,:

```
      let done = assert.async();
      let customDescription = "special description";
      let parent = make('parent');

      let updateMock = mockUpdate(parent);
     
      updateMock.match(function(requestData) {
        return requestData.children[0].description === customDescription;
      });
      profile.set('description', customDescription);
      profile.save().then(function(parent) {
        equal(updateMock.timesCalled, 1);
        done();
      });
```

One thing I don't like about this approach is that the caller needs to be aware of the adaptor type and process the `requestData` themselves to do the match. I think it's a reasonable compromise to get the flexibility of performing arbitrary matching.

I've given a stab at writing documentation and tests for this functionality. Happy to start a discussion and rework this PR if it seems like a sensible addition.

