### PR TITLE
Should matching non-existent attributes fail?

### DIFF
--- a/tests/unit/shared-factory-guy-test-helper-tests.js
+++ b/tests/unit/shared-factory-guy-test-helper-tests.js
@@ -1139,6 +1139,23 @@ SharedBehavior.mockCreateTests = function() {
     });
   });
 
+  test("don't match bogus attributes", function(assert) {
+    assert.expect(2);
+    Ember.run(() => {
+      let done = assert.async();
+      let customDescription = "special description";
+
+      let mock = mockCreate('profile').match({bogus: customDescription});
+
+      FactoryGuy.store.createRecord('profile').save().catch(() => {
+        ok(true);
+        // our mock was NOT called
+        equal(mock.timesCalled, 0);
+        done();
+      });
+    });
+  });
+
   test("match belongsTo association", function(assert) {
     Ember.run(()=> {
       let done = assert.async();
@@ -1629,6 +1646,25 @@ SharedBehavior.mockUpdateTests = function() {
         ok(profile.get('description') === customDescription);
         ok(profile.get('created_at').toString() === date.toString());
         ok(profile.get('aBooleanField') === true);
+        done();
+      });
+    });
+  });
+
+  test("don't match bogus attributes", function(assert) {
+    assert.expect(2);
+    Ember.run(() => {
+      let done = assert.async();
+      let customDescription = "special description";
+      let profile = make('profile');
+
+      mockUpdate('profile', profile.id).match({bogus: customDescription});
+
+      profile.set('description', customDescription);
+      profile.save().catch(() => {
+        ok(true);
+        // our mock was NOT called
+        equal(mock.timesCalled, 0);
         done();
       });
     });


### PR DESCRIPTION
**tl;dr** Passing an attribute to `match` with a bad/unknown name passes silently.

If you have a typo in attribute name  passed to `match` the test will pass, which is a little surprising. I would have expected this to fail. Feels a little dangerous to silently pass this case.

Happy to flesh this one out if you have any pointers. A naive solution might be to count the keys in the hash passed to `match` and ensure we're checking that many attributes in `matchCheckKeys` in `AttributeMatcher`?