### PR TITLE
Use assert rather than warn for missing traits

### DIFF
--- a/addon/model-definition.js
+++ b/addon/model-definition.js
@@ -139,9 +139,7 @@ class ModelDefinition {
   build(name, opts, traitArgs) {
     let traitsObj = {};
     traitArgs.forEach((trait)=> {
-      if (!this.traits[trait]) {
-        Ember.warn(`[ember-data-factory-guy] You're trying to use a trait [${trait}] for model ${this.modelName} but that trait can not be found.`, null, { id: 'ember-data-factory-guy-trait-does-not-exist' });
-      }
+      Ember.assert(`You're trying to use a trait [${trait}] for model ${this.modelName} but that trait can't be found.`, this.traits[trait]);
       $.extend(traitsObj, this.traits[trait]);
     });
     let modelAttributes = this.namedModels[name] || {};

--- a/tests/unit/factory-guy-test.js
+++ b/tests/unit/factory-guy-test.js
@@ -134,12 +134,12 @@ test("can use non model attributes to help setup attributes", function(assert) {
   assert.equal(dog2.get('sound'), `${volume} Woof`, 'uses your extra attribute');
 });
 
-test("emits warning when trait is not found", function(assert) {
-  sinon.spy(Ember, 'warn');
-//  Ember.warn = (args)=> console.log('do doo', args);
-  build('user', "non_existent_trait");
-  assert.ok(Ember.warn.getCall(0).args[0].match('non_existent_trait'));
-  Ember.warn.restore();
+test("causes an assertion error when a trait is not found", function(assert) {
+  try {
+    build('user', 'non_existent_trait');
+  } catch (error) {
+    assert.equal(error.message, "Assertion Failed: You're trying to use a trait [non_existent_trait] for model user but that trait can't be found.");
+  }
 });
 
 test("handles hash attribute with hash value as default value", function(assert) {

--- a/tests/unit/mock-request-test.js
+++ b/tests/unit/mock-request-test.js
@@ -263,7 +263,7 @@ test("with errors in response", function(assert) {
     const done = assert.async();
 
     const response = { errors: { description: ['bad'] } };
-    const mock = mockFindRecord('profile', 1).fails({ response });
+    const mock = mockFindRecord('profile').fails({ response });
 
     FactoryGuy.store.findRecord('profile', 1)
       .catch((res)=> {


### PR DESCRIPTION
We kinda discussed using assertions rather than warnings for missing traits in [another PR](https://github.com/danielspaniel/ember-data-factory-guy/pull/264#issuecomment-266524766). I decided to spike this out. 

If this is merged it might be worth flagging this - maybe this change is bigger than a patch release. It's possible it will cause test failures for people where before they were seeing (but perhaps not noticing or acting on) warnings that were there all along.