### PR TITLE
[WIP] use the new `store.isFragment` method

### DIFF
--- a/addon/model-definition.js
+++ b/addon/model-definition.js
@@ -39,6 +39,10 @@ class ModelDefinition {
    @returns {Boolean} true if it's a model fragment
    */
   isModelAFragment() {
+    if(FactoryGuy.store.isFragment) { //added in `ember-data-model-fragments` v2.11.0
+      return FactoryGuy.store.isFragment(this.modelName);
+    }
+
     try {
       if (FactoryGuy.store.createFragment) {
         return !!FactoryGuy.store.createFragment(this.modelName);


### PR DESCRIPTION
We are currently relying on [`store.createFragment` raising an exception](https://github.com/danielspaniel/ember-data-factory-guy/blob/20ba57cafaa366b59e62fd9e1afef01d5d673c53/addon/model-definition.js#L41-L50) to detect if a model is a factory. This exception comes from an assertion which will be stripped in certain builds once https://github.com/ember-cli/rfcs/pull/50 is adopted.

I recently added a [`store.isFragment`](https://github.com/lytics/ember-data-model-fragments/pull/235) method to `ember-data-model-fragments`. This hasn't yet been released, but when it is it would be nice to start using it.

TODO:

 * [x] Update the `added in 'ember-data-model-fragments' v2.3.x` comment once it has been released