### PR TITLE
Fix DjangoSerializer import

### DIFF
--- a/addon/builder/fixture-builder-factory.js
+++ b/addon/builder/fixture-builder-factory.js
@@ -9,6 +9,9 @@ import ActiveModelFixtureBuilder from './active-model-fixture-builder';
 let ActiveModelSerializer, DjangoSerializer;
 try {
   ActiveModelSerializer = require('active-model-adapter').ActiveModelSerializer;
+} catch (e) {
+}
+try {
   DjangoSerializer = require('ember-django-adapter/serializers/drf').default;
 } catch (e) {
 }


### PR DESCRIPTION
DjangoSerializer was not being imported when require for `ActiveModelSerializer` failed. I moved them into separate try/catch blocks.