### PR TITLE
fix build if ember-data-factory-guy used for tests inside addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = {
     // Not sure why this is necessary, but this stops the factory guy files
     // from being added to app tree. Would have thought that this would have
     // happened in treeForApp above, but not the case
-    if (!this.includeFactoryGuyFiles && this.treeExcludeRegex.test(name)) {
+    if (!this.includeFactoryGuyFiles && this.treeExcludeRegex && this.treeExcludeRegex.test(name)) {
       return;
     }
     return this._super.treeFor.apply(this, arguments);


### PR DESCRIPTION
Currently the build fails as `included` and `treeFor` hooks might be called in different contexts.

`included` hook is being run in `_notifyAddonIncluded` - https://github.com/ember-cli/ember-cli/blob/8637a9ab4a189cd375b309c44a66bdc6513f3bb2/lib/broccoli/ember-app.js#L508 and `treeFor` would be called in `addonTreeFor` - https://github.com/ember-cli/ember-cli/blob/8637a9ab4a189cd375b309c44a66bdc6513f3bb2/lib/broccoli/ember-app.js#L535.

The addon that has `ember-data-factory-guy` as its dependency would run default `ember-cli` `treeFor` implementation which would in turn call `eachAddonInvoke` - https://github.com/ember-cli/ember-cli/blob/8637a9ab4a189cd375b309c44a66bdc6513f3bb2/lib/models/addon.js#L462 to iterate over its own addons. 

For those addons the context would be different from one which is used when `included` hook is being run so `this.treeExcludeRegex` would be `undefined` and the error would be raised.