### PR TITLE
Silence JavaScript preprocessor deprecation warning on Ember 2.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   "license": "MIT",
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
-    "broccoli-merge-trees": "^1.1.1"
+    "broccoli-merge-trees": "^1.1.1",
+    "ember-cli-babel": "latest"
   },
   "devDependencies": {
     "active-model-adapter": "2.1.1",
     "broccoli-asset-rev": "^2.1.2",
     "ember-cli": "^2.12.0",
-    "ember-cli-babel": "latest",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-deprecation-workflow": "^0.2.3",
     "ember-cli-htmlbars": "1.1.1",


### PR DESCRIPTION
As of Ember 2.12 the addon started triggering the following deprecation warning:

```
DEPRECATION: Addon files were detected in `.../node_modules/ember-data-factory-guy/addon`, but no JavaScript preprocessors were found for `ember-data-factory-guy`.
Please make sure to add a preprocessor (most likely `ember-cli-babel`) to in `dependencies` (NOT `devDependencies`) in `ember-data-factory-guy`'s `package.json`.
```