### PR TITLE
Adding failing test to highlight meta information getting dropped from json requests

### DIFF
--- a/tests/acceptance/users-view-test.js
+++ b/tests/acceptance/users-view-test.js
@@ -1,5 +1,5 @@
 import {test} from 'qunit';
-import {buildList, makeList, mockFindAll} from 'ember-data-factory-guy';
+import {buildList, makeList, mockFindAll, mockQuery}  from 'ember-data-factory-guy';
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | Users View');
@@ -51,3 +51,11 @@ test("reuse mockFindAll to show return different users", async function(assert) 
   assert.ok(find('.user:last').text().match(bif.get('name')));
 });
 
+test('Load meta data returned from the server', async function(assert) {
+  let users = buildList('user', 1).add({ meta: { previous: '/profiles?page=1', next: '/profiles?page=3' }});
+  mockQuery('user', { page: 1 }).returns({ json: users });
+
+  await visit('/users');
+
+  assert.equal(find('.meta').length, 2);
+});

--- a/tests/dummy/app/routes/users.js
+++ b/tests/dummy/app/routes/users.js
@@ -2,6 +2,12 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model: function() {
-    return this.store.findAll('user');
+    let controller = this.controllerFor('users');
+
+    return this.store.query('user', {page: 1}).then(users => {
+      controller.set('previousPage', users.meta.previous);
+      controller.set('nextPage', users.meta.next);
+      return this.store.peekAll('user');
+    });
   }
 });

--- a/tests/dummy/app/templates/users.hbs
+++ b/tests/dummy/app/templates/users.hbs
@@ -1,1 +1,7 @@
 {{user-list users=model deleteUser=(action "deleteUser")}}
+{{#if next}}
+  <span class="meta">Next Page</span>
+{{/if}}
+{{#if previous}}
+  <span class="meta">Previous Page</span>
+{{/if}}


### PR DESCRIPTION
refers to https://github.com/danielspaniel/ember-data-factory-guy/issues/267

I also am experiencing this issue - here is a failing test to demonstrate (the same test as the one I found the issue from). If you put in a debugger in response returned in the users route from the query you will see the meta keyword is undefined. 