### PR TITLE
add failing test for factory inheritance

### DIFF
--- a/tests/dummy/app/models/cool-stoner.js
+++ b/tests/dummy/app/models/cool-stoner.js
@@ -1,0 +1,3 @@
+import Stoner from './stoner';
+
+export default Stoner.extend();

--- a/tests/unit/factory-guy-test.js
+++ b/tests/unit/factory-guy-test.js
@@ -252,6 +252,13 @@ test("default values and sequences are inherited", function(assert) {
     }
   });
 
+  FactoryGuy.define('cool-stoner', {
+    extends: 'stoner',
+    sequences: {
+      personName: (i)=> `cool stoner #${i}`
+    }
+  });
+
   let json;
 
   json = FactoryGuy.build('person').data;
@@ -265,6 +272,9 @@ test("default values and sequences are inherited", function(assert) {
 
   json = FactoryGuy.build('stoner').data;
   assert.equal(json.attributes.name, 'stoner #1', 'uses local sequence with inherited parent default attribute function');
+
+  json = FactoryGuy.build('cool-stoner').data;
+  assert.equal(json.attributes.name, 'cool stoner #1', 'uses local sequence with inherited parent default attribute function');
 
 });
 


### PR DESCRIPTION
I think I've found a situation where the inheritance doesn't work as expected.
Basically when we use more than one level, it doesn't seem to work. In the test, the overridden property is undefined. It also seems to happen with properties that are defined in the parent factories (they end up being undefined as well).