### PR TITLE
Remove reference to pretender-shim.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,11 +84,6 @@ module.exports = {
       app.import('vendor/fake-xml-http-request/' + path.basename(this._fakeRequestPath));
       app.import('vendor/route-recognizer/' + path.basename(this._routeRecognizerPath));
       app.import('vendor/pretender/' + path.basename(this._pretenderPath));
-      // not sure why this one is needed (but it is) borrowed it from mirage
-      app.import('vendor/pretender-shim.js', {
-        type: 'vendor',
-        exports: { 'pretender': ['default'] }
-      });
     }
   },
 


### PR DESCRIPTION
In upgrading to Ember 2.16.1 and Ember-Data 2.16.3 I now get the following error when I try to launch `error s` unless I remove the reference to pretender-shim.js.  Note that it was removed from ember-cli-pretender 10 months ago: https://github.com/rwjblue/ember-cli-pretender/commit/f25275e5e736387e1570b0b5ba99ac8c70d79e6e.

```
The Broccoli Plugin: [BroccoliMergeTrees: TreeMerger (vendor & appJS)] failed with:
Error: ENOENT: no such file or directory, open 'appDirectory/tmp/source_map_concat-input_base_path-wUctF9pK.tmp/vendor/pretender-shim.js'
    at Object.fs.openSync (fs.js:648:18)
    at Object.fs.readFileSync (fs.js:553:33)
    at SourceMap.addFile (appDirectory/node_modules/fast-sourcemap-concat/lib/source-map.js:75:31)
    at appDirectory/node_modules/broccoli-concat/concat.js:200:16
    at Array.forEach (<anonymous>)
    at Concat.<anonymous> (appDirectory/node_modules/broccoli-concat/concat.js:198:24)
    at appDirectory/node_modules/fast-sourcemap-concat/lib/source-map.js:419:12
    at initializePromise (appDirectory/node_modules/rsvp/dist/rsvp.js:567:5)
    at new Promise (appDirectory/node_modules/rsvp/dist/rsvp.js:1039:33)
    at SourceMap.end (appDirectory/node_modules/fast-sourcemap-concat/lib/source-map.js:406:10)

The broccoli plugin was instantiated at:
    at BroccoliMergeTrees.Plugin (appDirectory/node_modules/broccoli-plugin/index.js:7:31)
    at new BroccoliMergeTrees (appDirectory/node_modules/ember-cli/node_modules/broccoli-merge-trees/index.js:16:10)
    at Function.BroccoliMergeTrees [as _upstreamMergeTrees] (appDirectory/node_modules/ember-cli/node_modules/broccoli-merge-trees/index.js:10:53)
    at mergeTrees (appDirectory/node_modules/ember-cli/lib/broccoli/merge-trees.js:85:33)
    at Bundler.bundleJs (appDirectory/node_modules/ember-cli/lib/broccoli/bundler.js:171:24)
    at EmberAddon.javascript (appDirectory/node_modules/ember-cli/lib/broccoli/ember-app.js:1400:25)
    at EmberAddon.toArray (appDirectory/node_modules/ember-cli/lib/broccoli/ember-app.js:1785:12)
    at EmberAddon.toTree (appDirectory/node_modules/ember-cli/lib/broccoli/ember-app.js:1809:32)
    at module.exports (appDirectory/ember-cli-build.js:29:14)
    at Builder.setupBroccoliBuilder (appDirectory/node_modules/ember-cli/lib/models/builder.js:56:19)
```