### PR TITLE
Import pluralize from ember-inflector

### DIFF
--- a/addon/converter/rest-fixture-converter.js
+++ b/addon/converter/rest-fixture-converter.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import JSONFixtureConverter from './json-fixture-converter';
 
-const { pluralize, dasherize } = Ember.String;
+import { pluralize } from 'ember-inflector';
+const { dasherize } = Ember.String;
 
 /**
  Convert base fixture to a REST Serializer formatted payload.


### PR DESCRIPTION
This is to address a deprecation warning:

```
DEPRECATION: Ember.String.pluralize() is deprecated. Please explicitly: import { pluralize } from 'ember-inflector'; [deprecation id: ember-inflector.globals]
```