### PR TITLE
[BUGFIX] transform-object-rest-spread plugin must be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
     "ember-cli-babel": "^6.7.0",
@@ -30,7 +31,6 @@
   },
   "devDependencies": {
     "active-model-adapter": "2.1.1",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "broccoli-asset-rev": "^2.1.2",
     "ember-cli": "2.14",
     "ember-cli-dependency-checker": "^1.3.0",


### PR DESCRIPTION
Otherwise, the using application will break with a ReferenceError

```
The Broccoli Plugin: [BroccoliMergeTrees: TreeMerger (addons)] failed with:
ReferenceError: Unknown plugin "transform-object-rest-spread" specified in "base" at 0, attempted to resolve relative to "modules/ember-data-factory-guy/builder"
    at /Users/paul/Projects/ted/node_modules/ember-data-factory-guy/node_modules/babel-core/lib/transformation/file/options/option-manager.js:180:17
    at Array.map (native)
    ...
```