### PR TITLE
Propose changes to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ attributes will override any trait attributes or default attributes
 - Can setup belongsTo or hasMany associations manually
   - With `FactoryGuy.build`/`FactoryGuy.buildList` and `FactoryGuy.make`/`FactoryGuy.makeList`
     - Can compose relationships to any level
+  - When setting up manually do not mix `build` and `make` - you either `build` JSON in every levels of associations or `make` objects. `build` is taking serializer into account for every model which means that output from `build` might be different than expected input defined in factory in `make`.
 
 ##### Setup belongsTo associations in Factory Definitions
 
@@ -639,6 +640,7 @@ Usage:
   - for building json that you can pass as json payload in [acceptance tests](#acceptance-tests)
   - takes the same arguments as `FactoryGuy.make`
   - can compose relationships with other `FactoryGuy.build`/`FactoryGuy.buildList` payloads
+  - takes serializer for model into consideration
   - to inspect the json use the `get` method
   - use the [`add`](#using-add-method) method
     - to include extra sideloaded data to the payload
@@ -723,6 +725,7 @@ Usage:
   - for building json that you can pass as json payload in [acceptance tests](#acceptance-tests)
   - takes the same arguments as `FactoryGuy.makeList`
   - can compose relationships with other `build`/`buildList` payloads
+  - takes serializer for model into consideration
   - to inspect the json use the `get()` method
     - can use `get(index)` to get an individual item from the list
   - use the [`add`](#using-add-method) method
@@ -983,12 +986,18 @@ FactoryGuy.define('phone-number', {
     type: 'home'
   }
 });
+```
 
-// TIP: You can set up associations manually ( and not necessarily in a factory )
-// To set up an employee ( hasMany ) phone numbers manually, try this:
-let phoneNumbers = buildList('phone-numbers', 2).get();
+To set up associations manually ( and not necessarily in a factory ), you should do:
+
+```
+let phoneNumbers = makeList('phone-numbers', 2);
 let employee = make('employee', { phoneNumbers });
 
+// OR
+
+let phoneNumbers = buildList('phone-numbers', 2).get();
+let employee = build('employee', { phoneNumbers }).get();
 ```
 
 For a more detailed example of setting up fragments have a look at:

--- a/tests/acceptance/employee-view-test.js
+++ b/tests/acceptance/employee-view-test.js
@@ -1,5 +1,5 @@
 import {test} from 'qunit';
-import FactoryGuy,{make, build, buildList, mockFindRecord} from 'ember-data-factory-guy';
+import {make, build, buildList, mockFindRecord} from 'ember-data-factory-guy';
 import moduleForAcceptance from '../helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | Employee View ( model-fragments )');
@@ -17,6 +17,16 @@ test("Show employee by make(ing) a model ( with hasMany fragment added manually 
   assert.equal(find('.department-employment').length, 2, "fragment array works");
 });
 
+test("Show employee by make(ing) a model ( with belongsTo fragment added manually ) and using returns with that model", async function(assert) {
+  let name = make('name', { firstName: 'Joe', lastName: 'Black' });
+  let employee = make('employee', { name });
+
+  mockFindRecord('employee').returns({ model: employee });
+  await visit('/employee/' + employee.get('id'));
+
+  assert.ok(find('.name').text().match(`${employee.get('name.firstName')} ${employee.get('name.lastName')}`));
+});
+
 test("Show employee by make(ing) a model and using returns with that model", async function(assert) {
   let employee = make('employee', 'with_department_employments');
 
@@ -27,11 +37,9 @@ test("Show employee by make(ing) a model and using returns with that model", asy
   assert.equal(find('.department-employment').length, 2, "fragment array works");
 });
 
-test("Show employee by building(ing) json and using returns with that json", async function(assert) {
-  FactoryGuy.settings({logLevel: 1});
-//  console.log('me build',build('name', {firstName:'FFirst', lastName:'LLast'}));
-  // 'with_department_employments' is a trait that build the has many in the employee factory
+test("Show employee by build(ing) json and using returns with that json", async function(assert) {
   let employee = build('employee', 'with_department_employments');
+
   mockFindRecord('employee').returns({ json: employee });
   await visit('/employee/' + employee.get('id'));
 
@@ -39,7 +47,7 @@ test("Show employee by building(ing) json and using returns with that json", asy
   assert.equal(find('.department-employment').length, 2, "fragment array works");
 });
 
-test("Show employee by building(ing) json ( with hasMany fragment added manually ) and using returns with that json", async function(assert) {
+test("Show employee by build(ing) json ( with hasMany fragment added manually ) and using returns with that json", async function(assert) {
   let departmentEmployments = buildList('department-employment', 2).get();
   let employee = build('employee', { departmentEmployments });
 

--- a/tests/dummy/app/serializers/name.js
+++ b/tests/dummy/app/serializers/name.js
@@ -3,8 +3,6 @@ import DS from 'ember-data';
 
 export default DS.RESTSerializer.extend({
   keyForAttribute(attr) {
-//    console.log('name here',Ember.String.decamelize(attr));
     return Ember.String.decamelize(attr);
-//    return this._super(...arguments);
   }
 });


### PR DESCRIPTION
I suggest a couple of small changes to documentation to make it easier to understand that mixing `build` and `make` can have unpredictable results. I also underline that serializers are taken into consideration in `build` methods (what might be obvious, but I feel that it is easy to forget about).

Also small clean up in acceptance tests regarding model fragments.