### PR TITLE
Fixes Issue 320 => mockGetRequest with model changes object type

### DIFF
--- a/addon/mocks/mock-get-request.js
+++ b/addon/mocks/mock-get-request.js
@@ -100,7 +100,7 @@ class MockGetRequest extends MockStoreRequest {
           ${Ember.typeOf(models)}`, Ember.isArray(models));
 
         json = models.map(model => {
-          return {id: model.id, type: model.constructor.modelName};
+          return {id: model.id}
         });
 
         json = this.fixtureBuilder.convertForBuild(modelName, json);

--- a/tests/acceptance/cat-test.js
+++ b/tests/acceptance/cat-test.js
@@ -1,0 +1,28 @@
+import {test} from 'qunit';
+import {make, mockFindAll} from 'ember-data-factory-guy';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | Cat View');
+
+function assertCatIsCute(cat, assert) {
+  assert.equal('Cute', cat.get('type'));
+}
+
+test('cat type does not change', function(assert) {
+  const cat = make('cat');
+  assertCatIsCute(cat, assert); // make is fine
+
+  mockFindAll('cat').returns({
+    models: [cat],
+  });
+  assertCatIsCute(cat, assert); // Mocked payload hasn't yet been pushed to store
+
+  // Having some kind of button would make a nicer test
+  const store = this.application.__container__.lookup('service:store');
+  assertCatIsCute(cat, assert); // Mocked payload hasn't yet been pushed to store
+  store.findAll('cat') // Triggering the request
+  visit('/') // Doing something so that the app and the run loop and maybe other things do run
+  andThen(() => {
+    assertCatIsCute(cat, assert); // This should not fail, but it does
+  });
+});


### PR DESCRIPTION
The test is quite ugly but demonstrates the problem (see first commit)
Second commit fixes the issue and does not break any test, but it a bit surprising, so maybe this is necessary for some cases that are not documented in tests.

The test would need to be cleaned up before merge if ok on principe