### PR TITLE
Exposed mock method to scenarios

### DIFF
--- a/addon/scenario.js
+++ b/addon/scenario.js
@@ -5,7 +5,7 @@ let proxyFx = [
   'make', 'makeNew', 'makeList', 'build', 'buildList',
   'mockFind', 'mockFindRecord', 'mockFindAll',
   'mockReload', 'mockQuery', 'mockQueryRecord',
-  'mockUpdate', 'mockCreate', 'mockDelete'
+  'mockUpdate', 'mockCreate', 'mockDelete', 'mock'
 ];
 
 export default class {


### PR DESCRIPTION
Super simple change. The `mock` method wasn't exposed to scenarios.