### PR TITLE
mergeDeep: Add `hasOwnProperty()` check

### DIFF
--- a/addon/utils/helper-functions.js
+++ b/addon/utils/helper-functions.js
@@ -69,13 +69,15 @@ export function mergeDeep(target, ...sources) {
 
   if (isObject(target) && isObject(source)) {
     for (const key in source) {
-      if (isObject(source[key])) {
-        if (!target[key]) {
-          assign(target, { [key]: {} });
+      if (source.hasOwnProperty(key)) {
+        if (isObject(source[key])) {
+          if (!target[key]) {
+            assign(target, { [key]: {} });
+          }
+          mergeDeep(target[key], source[key]);
+        } else {
+          assign(target, { [key]: source[key] });
         }
-        mergeDeep(target[key], source[key]);
-      } else {
-        assign(target, { [key]: source[key] });
       }
     }
   }


### PR DESCRIPTION
Without this change our tests are running into errors like described in https://github.com/emberjs/ember.js/issues/16049, because computed properties are included in the for-in loop and the nested `mergeDeep()` call will try to clone `isDescriptor` and other internal properties of the computed property.

Related to https://github.com/danielspaniel/ember-data-factory-guy/issues/328

/cc @danielspaniel 