### PR TITLE
Non-polymorphic embedded hasMany works with AMS

### DIFF
--- a/addon/converter/fixture-converter.js
+++ b/addon/converter/fixture-converter.js
@@ -94,7 +94,7 @@ export default class {
   }
 
   transformRelationshipKey(relationship) {
-    let transformFn = this.getTransformKeyFunction(relationship.type, 'Relationship');
+    let transformFn = this.getTransformKeyFunction(relationship.parentType.modelName, 'Relationship');
     return transformFn(relationship.key, relationship.kind);
   }
 
@@ -135,7 +135,7 @@ export default class {
           attrName = attrOptions;
         }
       }
-      return attrName || keyFn.apply(this, [attribute, method]);
+      return attrName || keyFn.apply(serializer, [attribute, method, 'serialize']);
     });
   }
 
@@ -240,7 +240,7 @@ export default class {
   extractHasMany(fixture, relationship, parentModelName, relationships) {
     let hasManyRecords  = fixture[relationship.key],
         relationshipKey = this.transformRelationshipKey(relationship),
-        isEmbedded      = this.isEmbeddedRelationship(parentModelName, relationshipKey),
+        isEmbedded      = this.isEmbeddedRelationship(parentModelName, relationship.key),
         isLinks         = hasManyRecords && hasManyRecords.links;
 
     if (isLinks) {

--- a/tests/dummy/app/models/comic-book.js
+++ b/tests/dummy/app/models/comic-book.js
@@ -6,4 +6,5 @@ export default Model.extend({
   name: attr('string'),
   company: belongsTo('company'),
   characters: hasMany('person', { polymorphic: true }),
+  includedVillains: hasMany('villain'),
 });

--- a/tests/dummy/app/tests/factories/comic-book.js
+++ b/tests/dummy/app/tests/factories/comic-book.js
@@ -13,6 +13,9 @@ FactoryGuy.define('comic-book', {
     },
     with_good_guys: {
       characters: FactoryGuy.hasMany('bat_man', 2)
+    },
+    with_included_villains: {
+      includedVillains: FactoryGuy.hasMany('villain', 2)
     }
   }
 });

--- a/tests/helpers/utility-methods.js
+++ b/tests/helpers/utility-methods.js
@@ -56,6 +56,7 @@ const serializerOptions = {
   'comic-book': [
     DS.EmbeddedRecordsMixin, {
       attrs: {
+        includedVillains: { embedded: 'always' },
         company: { embedded: 'always' }, characters: { embedded: 'always' }
       }
     }

--- a/tests/unit/active-model-adapter-test.js
+++ b/tests/unit/active-model-adapter-test.js
@@ -42,6 +42,25 @@ test("returns camelCase attributes", async function(assert) {
 
 moduleFor('serializer:application', `${serializer} FactoryGuy#build custom`, inlineSetup(serializerType));
 
+test("embeds polymorphic hasMany record when serializer attrs => embedded: always ", function(assert) {
+
+  let buildJson = build('comic-book', 'with_bad_guys');
+  buildJson.unwrap();
+
+  let expectedJson = {
+    comic_book: {
+      id: 1,
+      name: 'Comic Times #1',
+      characters: [
+        { id: 1, type: 'Villain', name: 'BadGuy#1' },
+        { id: 2, type: 'Villain', name: 'BadGuy#2' },
+      ]
+    }
+  };
+
+  assert.deepEqual(buildJson, expectedJson);
+});
+
 test("embeds belongsTo record when serializer attrs => embedded: always ", function(assert) {
 
   let buildJson = build('comic-book', 'marvel');

--- a/tests/unit/active-model-adapter-test.js
+++ b/tests/unit/active-model-adapter-test.js
@@ -42,6 +42,25 @@ test("returns camelCase attributes", async function(assert) {
 
 moduleFor('serializer:application', `${serializer} FactoryGuy#build custom`, inlineSetup(serializerType));
 
+test("embeds hasMany record when serializer attrs => embedded: always ", function(assert) {
+
+  let buildJson = build('comic-book', 'with_included_villains');
+  buildJson.unwrap();
+
+  let expectedJson = {
+    comic_book: {
+      id: 1,
+      name: 'Comic Times #1',
+      included_villains: [
+        { id: 1, type: 'Villain', name: 'BadGuy#1' },
+        { id: 2, type: 'Villain', name: 'BadGuy#2' },
+      ]
+    }
+  };
+
+  assert.deepEqual(buildJson, expectedJson);
+});
+
 test("embeds polymorphic hasMany record when serializer attrs => embedded: always ", function(assert) {
 
   let buildJson = build('comic-book', 'with_bad_guys');

--- a/tests/unit/json-adapter-test.js
+++ b/tests/unit/json-adapter-test.js
@@ -125,7 +125,7 @@ test("embeds belongsTo record passed as prebuilt ( build ) json when serializer 
   assert.deepEqual(buildJson, expectedJson);
 });
 
-test("embeds hasMany records when serializer attrs => embedded: always", function(assert) {
+test("embeds polymorphic hasMany records when serializer attrs => embedded: always", function(assert) {
 
   let buildJson = build('comic-book', 'with_bad_guys');
   buildJson.unwrap();

--- a/tests/unit/json-adapter-test.js
+++ b/tests/unit/json-adapter-test.js
@@ -125,6 +125,23 @@ test("embeds belongsTo record passed as prebuilt ( build ) json when serializer 
   assert.deepEqual(buildJson, expectedJson);
 });
 
+test("embeds hasMany records when serializer attrs => embedded: always", function(assert) {
+
+  let buildJson = build('comic-book', 'with_included_villains');
+  buildJson.unwrap();
+
+  let expectedJson = {
+    id: 1,
+    name: 'Comic Times #1',
+    includedVillains: [
+      {id: 1, type: 'Villain', name: 'BadGuy#1'},
+      {id: 2, type: 'Villain', name: 'BadGuy#2'}
+    ]
+  };
+
+  assert.deepEqual(buildJson, expectedJson);
+});
+
 test("embeds polymorphic hasMany records when serializer attrs => embedded: always", function(assert) {
 
   let buildJson = build('comic-book', 'with_bad_guys');

--- a/tests/unit/rest-adapter-test.js
+++ b/tests/unit/rest-adapter-test.js
@@ -480,7 +480,7 @@ test("embeds belongsTo record passed as prebuilt ( build ) json when serializer 
   assert.deepEqual(buildJson, expectedJson);
 });
 
-test("embeds hasMany records when serializer attrs => embedded: always", function(assert) {
+test("embeds polymorphic hasMany records when serializer attrs => embedded: always", function(assert) {
 
   let buildJson = build('comic-book', 'with_bad_guys');
   buildJson.unwrap();

--- a/tests/unit/rest-adapter-test.js
+++ b/tests/unit/rest-adapter-test.js
@@ -480,6 +480,25 @@ test("embeds belongsTo record passed as prebuilt ( build ) json when serializer 
   assert.deepEqual(buildJson, expectedJson);
 });
 
+test("embeds hasMany records when serializer attrs => embedded: always", function(assert) {
+
+  let buildJson = build('comic-book', 'with_included_villains');
+  buildJson.unwrap();
+
+  let expectedJson = {
+    comicBook: {
+      id: 1,
+      name: 'Comic Times #1',
+      includedVillains: [
+        {id: 1, type: 'Villain', name: 'BadGuy#1'},
+        {id: 2, type: 'Villain', name: 'BadGuy#2'}
+      ]
+    }
+  };
+
+  assert.deepEqual(buildJson, expectedJson);
+});
+
 test("embeds polymorphic hasMany records when serializer attrs => embedded: always", function(assert) {
 
   let buildJson = build('comic-book', 'with_bad_guys');


### PR DESCRIPTION
It seems that at the moment there is only test coverage for embedded, polymorphic hasMany relationships - but not for non-polymorphic ones.

Non-polymorphic embedded hasMany works for rest and json serializer, but it doesn't with the ActiveModelSerializer.

The fix basically includes 3 changes in the codebase, which hopefully are comprehensible. I will add some comments for further explanation.

Happy to update this PR, split it up so it only contains the fix (and add test coverage in a separate PR). Also, let me know if there is something I've missed, but testing wise the fixes seem not to influence other parts, even though the 3 changes look more substantial...