### PR TITLE
Fix issue with buildList and a count of 0

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -319,7 +319,7 @@ class FactoryGuy {
   buildRawList({name, number, opts, buildType = 'build'} = {}) {
     let definition = FactoryGuy.lookupDefinitionForFixtureName(name, true);
 
-    if (number) {
+    if (number != null) {
       let parts = FactoryGuy.extractArgumentsShort(...opts);
       return definition.buildList(name, number, parts.traits, parts.opts, buildType);
     }

--- a/tests/unit/factory-guy-test.js
+++ b/tests/unit/factory-guy-test.js
@@ -890,6 +890,14 @@ module('FactoryGuy', function(hooks) {
         {id: 2, title: 'Really Big'}
       ];
       assert.deepEqual(projectList, expected);
+
+      projectList = FactoryGuy.buildRawList({
+        name: 'project',
+        number: 0,
+        opts: ['big', {title: 'Really Big'}]
+      });
+      expected = [];
+      assert.deepEqual(projectList, expected);
     });
 
     test("using diverse attributes", function(assert) {


### PR DESCRIPTION
Fixes the following issue where passing `0` to `buildList` doesn't work correctly.

``` js
// before fix
buildList('article', 0, 'published', { folder: home, owner: 29 }).length => 2

// after fix
buildList('article', 0, 'published', { folder: home, owner: 29 }).length => 0
```