### PR TITLE
Add postSetup hook

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -24,12 +24,14 @@ class FactoryGuy {
    *
    * responseTime: 0 is fastest
    * logLevel: 0 is off, 1 is on
+   * postSetup: a hook to run after Factory Guy sets up
    *
    * @param logLevel [0/1]
    */
-  settings({logLevel = 0, responseTime = null} = {}) {
+  settings({logLevel = 0, responseTime = null, postSetup = null} = {}) {
     RequestManager.settings({responseTime});
     this.logLevel = logLevel;
+    this.postSetup = postSetup;
     return RequestManager.settings();
   }
 

--- a/addon/utils/manual-setup.js
+++ b/addon/utils/manual-setup.js
@@ -10,5 +10,8 @@ export default function(scope) {
   FactoryGuy.setStore(owner.lookup('service:store'));
   loadFactories();
   loadScenarios(owner);
+  if (FactoryGuy.postSetup) {
+    FactoryGuy.postSetup();
+  }
 }
 

--- a/tests/unit/factory-guy-test.js
+++ b/tests/unit/factory-guy-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import DS from 'ember-data';
 import Ember from 'ember';
 import FactoryGuy, {
-  make, makeNew, makeList, build, buildList, attributesFor
+  manualSetup, make, makeNew, makeList, build, buildList, attributesFor
 } from 'ember-data-factory-guy';
 import MissingSequenceError from 'ember-data-factory-guy/missing-sequence-error';
 import sinon from 'sinon';
@@ -23,13 +23,19 @@ module('FactoryGuy', function(hooks) {
 
   test("#settings", function(assert) {
     FactoryGuy.logLevel = 0;
-    FactoryGuy.settings({responseTime: 0});
+    FactoryGuy.settings({responseTime: 0, postSetup: null});
 
     FactoryGuy.settings({logLevel: 1});
     assert.equal(FactoryGuy.logLevel, 1);
 
     FactoryGuy.settings({responseTime: 10});
     assert.equal(RequestManager.settings().responseTime, 10);
+
+    let postSetup = sinon.spy();
+    FactoryGuy.settings({postSetup});
+    manualSetup(this);
+    assert.equal(FactoryGuy.postSetup, postSetup);
+    assert.ok(postSetup.called);
   });
 
   test("exposes make method which is shortcut for FactoryGuy.make", function(assert) {


### PR DESCRIPTION
### Why?
I'd like some sort of hook which Factory Guy would run after set up has occurred for each test, i.e. `manualSetup`. Rather than have to add logic to each individual unit, integration and acceptance test and I'd like to be able to set it in a single place, for example in `tests/test-helper.js`. In my particular use case what I want to do is get access to the `Pretender` instance and set custom `unhandledRequest` or `erroredRequest` handlers.

### How?
I've added a new property `FactoryGuy#postSetup` which is set through the `settings` hash

``` js
FactoryGuy.settings({
  postSetup() {
    // my custom logic
  }
});

// in manualSetup
FactoryGuy.postSetup();
```

I'm not tied to the `postSetup` name so if you have any better suggestions? Also if you know of a way to achieve this without needing to add this PR I'd love to know.