### PR TITLE
Update testem.js

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -1,21 +1,24 @@
 /* eslint-env node */
 module.exports = {
-  "framework": "qunit",
-  "test_page": "tests/index.html?hidepassed",
-  "disable_watching": true,
-  "launch_in_ci": [
-    "Chrome"
-  ],
-  "launch_in_dev": [
-    "Chrome"
-  ],
+  framework: 'qunit',
+  test_page: 'tests/index.html?hidepassed',
+  disable_watching: true,
+  reporter: 'dot',
+  launch_in_ci: ['Chrome'],
+  launch_in_dev: ['Chrome'],
   browser_args: {
-    Chrome: [
-      '--disable-gpu',
-      '--headless',
-      '--remote-debugging-port=9222',
-      '--window-size=1440,900'
-    ]
-  }
-
+    Chrome: {
+      mode: 'ci',
+      args: [
+        '--headless',
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        '--mute-audio',
+        '--remote-debugging-port=0',
+        '--window-size=1440,900',
+        '--no-sandbox',
+      ],
+    },
+  },
 };


### PR DESCRIPTION
The above flags improve the stability of using Chrome, and will be required for ember-data to be able to run CI tests that include ember-data-factory-guy tests