### PR TITLE
Allow `make` to return an instance of `ModelFragment`

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -379,7 +379,7 @@ class FactoryGuy {
         fixture     = this.buildRaw(assign(args, {buildType: 'make'}));
 
     if (this.isModelAFragment(modelName)) {
-      return fixture;
+      return this.store.createFragment(modelName, fixture);
     }
 
     let data  = this.fixtureBuilder(modelName).convertForMake(modelName, fixture),

--- a/tests/unit/factory-guy-test.js
+++ b/tests/unit/factory-guy-test.js
@@ -9,6 +9,7 @@ import MissingSequenceError from 'ember-data-factory-guy/missing-sequence-error'
 import sinon from 'sinon';
 import { inlineSetup } from '../helpers/utility-methods';
 import User from 'dummy/models/user';
+import Name from 'dummy/models/name';
 import RequestManager from 'ember-data-factory-guy/mocks/request-manager';
 
 const A = Ember.A;
@@ -144,9 +145,10 @@ module('FactoryGuy', function(hooks) {
       assert.ok(user instanceof User);
     });
 
-    test("returns a json for model fragment", function(assert) {
-      let json = FactoryGuy.make('name');
-      assert.deepEqual(json, {firstName: 'Tyrion', lastName: 'Lannister'});
+    test("returns a fragment for model fragment", function(assert) {
+      let name = FactoryGuy.make('name');
+      assert.ok(name instanceof Name, 'The fragment is a Name fragment');
+      assert.equal(name.get('firstName'), 'Tyrion', 'The firstName is correct');
     });
   });
 


### PR DESCRIPTION
Currently if you use `FactoryGuy#make` to generate a `ModelFragment` it returns a json hash of the properties of the fragment. In keeping with the consistency of using `Factory#make` for a regular Ember Data record, I think it should return an actual model instance instead, in this case a `ModelFragment`.

