### PR TITLE
Create fragment inside a run loop

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -379,7 +379,7 @@ class FactoryGuy {
         fixture     = this.buildRaw(assign(args, {buildType: 'make'}));
 
     if (this.isModelAFragment(modelName)) {
-      return this.store.createFragment(modelName, fixture);
+      return join(() => this.store.createFragment(modelName, fixture));
     }
 
     let data  = this.fixtureBuilder(modelName).convertForMake(modelName, fixture),


### PR DESCRIPTION
After pulling the latest version with [my fragment fix](https://github.com/danielspaniel/ember-data-factory-guy/pull/362) into my app we started getting asynchronous errors when creating fragments directly using `make`. I've updated to create the fragment inside a run loop. This is similar to what we do when pushing records into the regular store just below these lines.

``` js
model = join(() => this.store.push(data));
```

### Before
![image](https://user-images.githubusercontent.com/685034/44739162-f427fd80-aaee-11e8-9801-b2f2e09735e3.png)

### After
![image](https://user-images.githubusercontent.com/685034/44739290-4406c480-aaef-11e8-9dee-1a37bd4f0567.png)
