### PR TITLE
Update codebase to follow Ember RFC 176

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Feel the thrill and enjoyment of testing when using Factories instead of Fixture
 Factories simplify the process of testing, making you more efficient and your tests more readable.
 
 **NEW** starting with v3.2.1
-  - You can setup data AND links for your async relationship[Check it out](#special-tips-for-links) 
-                                                                                              
+  - You can setup data AND links for your async relationship[Check it out](#special-tips-for-links)
+
 **NEW** You can use factory guy in ember-twiddle
-  - Using [Scenarios](https://ember-twiddle.com/421f16ecc55b5d35783c243b8d99f2be?openFiles=tests.unit.model.user-test.js%2C) 
-     
+  - Using [Scenarios](https://ember-twiddle.com/421f16ecc55b5d35783c243b8d99f2be?openFiles=tests.unit.model.user-test.js%2C)
+
 **NEW** If using new style of ember-qunit acceptance tests with ```setupApplicationTest``` check out demo here: [user-view-test.js:](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/acceptance/user-view-test.js)
 
 **NEW** starting with v2.13.27
@@ -33,7 +33,7 @@ Factories simplify the process of testing, making you more efficient and your te
 - You don't need to add any files to recreate the relationships in your models
 - Any custom methods like: serialize / serializeAttribute / keyForAttribute etc... in a serializer will be used automatically
 - If you set up custom methods like: buildURL / urlForFindRecord in an adapter, they will be used automatically
-- You have no config file with tons of spew, because you declare all the mocks and make everything declaratively in the test 
+- You have no config file with tons of spew, because you declare all the mocks and make everything declaratively in the test
 - You can push models and their complex relationships directly to the store
 
 ### Questions / Get in Touch
@@ -295,7 +295,7 @@ In other words, don't do this:
 - Can use one or more traits
  - Each trait overrides any values defined in traits before it in the argument list
 - traits can be functions ( this is mega powerful )
- 
+
 ```javascript
 
   FactoryGuy.define('user', {
@@ -331,7 +331,7 @@ attributes will override any trait attributes or default attributes
 
 ##### Using traits as functions
 
-```js     
+```js
 import FactoryGuy from 'ember-data-factory-guy';
 
 FactoryGuy.define("project", {
@@ -385,20 +385,20 @@ Your trait function assigns the title as you described in the function
     - Can compose relationships to any level
   - When setting up manually do not mix `build` and `make` - you either `build` JSON in every levels of associations or `make` objects. `build` is taking serializer into account for every model which means that output from `build` might be different than expected input defined in factory in `make`.
 
-- Special tips for links 
+- Special tips for links
 
 ##### Setup belongsTo associations in Factory Definitions
 
 - using traits are the best practice
-  
+
 ```javascript
   FactoryGuy.define('project', {
-    
+
     traits: {
       withUser: { user: {} },
       withAdmin: { user: FactoryGuy.belongsTo('user', 'admin') },
       withManagerLink(f) { // f is the fixture being created
-        f.links = {manager: `/projects/${f.id}/manager`} 
+        f.links = {manager: `/projects/${f.id}/manager`}
       }
     }
   });
@@ -408,7 +408,7 @@ Your trait function assigns the title as you described in the function
 
   user = make('user', 'withManagerLink');
   user.belongsTo('manager').link(); // => "/projects/1/manager"
-   
+
 ```
 
 
@@ -442,16 +442,16 @@ the reverse user hasMany 'projects' association is being setup for you on the us
       withProjects: {
         projects: FactoryGuy.hasMany('project', 2)
       },
-      withPropertiesLink(f) { // f is the fixture being created 
-        f.links = {properties: `/users/${f.id}/properties`} 
+      withPropertiesLink(f) { // f is the fixture being created
+        f.links = {properties: `/users/${f.id}/properties`}
       }
     }
   });
 
   let user = make('user', 'withProjects');
   user.get('projects.length') // => 2
-  
-  user = make('user', 'withPropertiesLink'); 
+
+  user = make('user', 'withPropertiesLink');
   user.hasMany('properties').link(); // => "/users/1/properties"
 ```
 
@@ -459,9 +459,9 @@ the reverse user hasMany 'projects' association is being setup for you on the us
 
 ```javascript
   FactoryGuy.define('user', {
-    
+
     userWithProjects: { projects: FactoryGuy.hasMany('project', 2) }
-  
+
   });
 
   let user = make('userWithProjects');
@@ -495,39 +495,39 @@ the reverse 'user' belongsTo association is being setup for you on the project
 ##### Special tips for links
   - The links syntax changed as of ( v3.2.1 )
     - What you see below is the new syntax
-  - You can setup data AND links for your async relationship 
+  - You can setup data AND links for your async relationship
   - Need special care with multiple traits setting links
-  
+
 ```javascript
 
   FactoryGuy.define('user', {
     traits: {
       withCompanyLink(f): {
         // since you can assign many different links with different traits,
-        // you should Object.assign so that you add to the links hash rather 
-        // than set it directly ( assuming you want to use this feature ) 
+        // you should Object.assign so that you add to the links hash rather
+        // than set it directly ( assuming you want to use this feature )
         f.links = Object.assign({company: `/users/${f.id}/company`}, f.links);
       },
-      withPropertiesLink(f) {  
-        f.links = Object.assign({properties: `/users/${f.id}/properties`}, f.links); 
+      withPropertiesLink(f) {
+        f.links = Object.assign({properties: `/users/${f.id}/properties`}, f.links);
       }
     }
   });
-  
-  // setting links with traits 
+
+  // setting links with traits
   let company = make('company')
   let user = make('user', 'withCompanyLink', 'withPropertiesLink', {company});
   user.hasMany('properties').link(); // => "/users/1/properties"
   user.belongsTo('company').link(); // => "/users/1/company"
-  // the company async relationship has a company AND link to fetch it again 
-  // when you reload that relationship 
+  // the company async relationship has a company AND link to fetch it again
+  // when you reload that relationship
   user.get('company.content') // => company
   user.belongsTo('company').reload() // would use that link "/users/1/company" to reload company
-  
-  // you can also set traits with your build/buildList/make/makeList options 
-  user = make('user', {links: {properties: '/users/1/properties'}});   
+
+  // you can also set traits with your build/buildList/make/makeList options
+  user = make('user', {links: {properties: '/users/1/properties'}});
 ```
-  
+
 ### Extending Other Definitions
   - Extending another definition will inherit these sections:
     - sequences
@@ -616,7 +616,7 @@ Assuming the factory-guy model definition defines `afterMake` function:
 You would use this to make models like:
 
 ```javascript
-  Ember.run(function () {
+  run(function () {
 
     let property = FactoryGuy.make('property');
     property.get('name'); // => 'Silly property(FOR SALE)')
@@ -626,6 +626,8 @@ You would use this to make models like:
   });
 
 ```
+
+Remember to import the `run` function with `import { run } from "@ember/runloop"`;
 
 ### Using Factories
  - [`FactoryGuy.attributesFor`](#factoryguyattributesfor)
@@ -649,20 +651,20 @@ You would use this to make models like:
  - Can compose relationships
     - By passing in other objects you've made with `build`/`buildList` or `make`/`makeList`
  - Can setup links for async relationships with `build`/`buildList` or `make`/`makeList`
- 
+
 ##### `FactoryGuy.attributesFor`
   - nice way to get attibutes for a factory without making a model or payload
   - same arguments as make/build
-  - no id is returned 
-  - no relationship info returned ( yet )  
-  
+  - no id is returned
+  - no relationship info returned ( yet )
+
 ```javascript
 
   import { attributesFor } from 'ember-data-factory-guy';
 
   // make a user with certain traits and options
   attributesFor('user', 'silly', {name: 'Fred'}); // => { name: 'Fred', style: 'silly'}
-  
+
 ```
 
 ##### `FactoryGuy.make`
@@ -710,7 +712,7 @@ You would use this to make models like:
 
   // make user with links to async hasMany properties
   let user = make('user', {properties: {links: '/users/1/properties'}});
-  
+
   // make user with links to async belongsTo company
   let user = make('user', {company: {links: '/users/1/company'}});
 
@@ -721,7 +723,7 @@ You would use this to make models like:
 
 ##### `FactoryGuy.makeNew`
   - Same api as `FactoryGuy.make`
-    - except that the model will be a newly created record with no id 
+    - except that the model will be a newly created record with no id
 
 ##### `FactoryGuy.makeList`
   - check out [(user factory):](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/dummy/app/tests/factories/user.js) to see 'bob' user and 'with_car' trait
@@ -806,10 +808,10 @@ Usage:
 
   // build user with links to async hasMany properties
   let user = build('user', {properties: {links: '/users/1/properties'}});
-  
+
   // build user with links to async belongsTo company
   let user = build('user', {company: {links: '/users/1/company'}});
-  
+
 ```
 - Example of what json payload from build looks like
  - Although the RESTAdapter is being used, this works the same with ActiveModel or JSONAPI adapters
@@ -1211,13 +1213,13 @@ test("Using FactoryGuy.cacheOnlyMode with except", async function() {
 - FactoryGuy needs to setup the factories before the test run.
   - By default, you only need to call `manualSetup(this)` in unit/component/acceptance tests
   - Or you can use the new setupFactoryGuy(hooks) method if your using the new qunit style tests
-  
+
     - Sample usage: (works the same in any type of test)
     ```js
     module('Acceptance | User View', function(hooks) {
       setupApplicationTest(hooks);
       setupFactoryGuy(hooks);
-    
+
       test("blah blah", async function(assert) {
          await visit('work');
          assert.ok('bah was spoken');
@@ -1673,7 +1675,7 @@ Usage:
           json, returning `true` if there is a match, `false` otherwise.
     - returns
       - attributes ( including relationships ) to include in response json
-  - Need to wrap tests using `mockCreate` with: `Ember.run(function() { 'your test' })`
+  - Need to import `run` from `@ember/runloop` and wrap tests using `mockCreate` with: `run(function() { 'your test' })`
 
 Realistically, you will have code in a view action or controller action that will
  create the record, and setup any associations.
@@ -1759,7 +1761,7 @@ Usage:
         json, returning `true` if there is a match, `false` otherwise.
     - returns
       - attributes ( including relationships ) to include in response json
-  - Need to wrap tests using `mockUpdate` with: `Ember.run(function() { 'your test' })`
+  - Need to import `run` from `@ember/runloop` and wrap tests using `mockUpdate` with: `run(function() { 'your test' })`
 
 Usage:
 
@@ -1857,7 +1859,7 @@ Usage:
 
 
 ##### `mockDelete`
-  - Need to wrap tests using `mockDelete` with: `Ember.run(function() { 'your test' })`
+  - Need to import `run` from `@ember/runloop` and wrap tests using `mockDelete` with: `run(function() { 'your test' })`
   - To handle deleting a model
     - Pass in a record ( or a typeName and id )
 

--- a/addon/mocks/mock-request.js
+++ b/addon/mocks/mock-request.js
@@ -1,7 +1,12 @@
 import { assert } from '@ember/debug';
 import { assign } from '@ember/polyfills';
 import $ from 'jquery';
-import { isEmptyObject, isEquivalent, isPartOf, toParams } from '../utils/helper-functions';
+import {
+  isEmptyObject,
+  isEquivalent,
+  isPartOf,
+  toParams
+} from '../utils/helper-functions';
 import FactoryGuy from '../factory-guy';
 import RequestManager from './request-manager';
 

--- a/addon/payload/json-api-payload.js
+++ b/addon/payload/json-api-payload.js
@@ -1,6 +1,6 @@
 import { isEmpty } from '@ember/utils';
 import { typeOf } from '@ember/utils';
-import $ from 'jquery';
+import { assign } from '@ember/polyfills';
 import BasePayload from './base-payload';
 
 export default class extends BasePayload {
@@ -47,7 +47,7 @@ export default class extends BasePayload {
     Object.keys(data.relationships||[]).forEach((key)=> {
       relationships[key] = data.relationships[key].data;
     });
-    let attrs = $.extend({}, data.attributes, relationships);
+    let attrs = assign({}, data.attributes, relationships);
     attrs.id = data.id;
     return attrs;
   }

--- a/addon/utils/load-factories.js
+++ b/addon/utils/load-factories.js
@@ -1,4 +1,4 @@
-import {requireFiles} from './helper-functions';
+import { requireFiles } from './helper-functions';
 
 const factoryFileRegExp = new RegExp('/tests/factories');
 

--- a/addon/utils/load-scenarios.js
+++ b/addon/utils/load-scenarios.js
@@ -1,5 +1,5 @@
 import { assert } from '@ember/debug';
-import {requireFiles} from './helper-functions';
+import { requireFiles } from './helper-functions';
 
 const scenarioFileRegExp = new RegExp('/scenarios/main$');
 /**

--- a/tests/acceptance/employee-view-test.js
+++ b/tests/acceptance/employee-view-test.js
@@ -1,5 +1,11 @@
 import { module, test } from 'qunit';
-import { build, buildList, make, mockFindRecord, setupFactoryGuy } from 'ember-data-factory-guy';
+import {
+  build,
+  buildList,
+  make,
+  mockFindRecord,
+  setupFactoryGuy
+} from 'ember-data-factory-guy';
 import { setupApplicationTest } from "ember-qunit";
 import { visit } from '@ember/test-helpers';
 

--- a/tests/acceptance/profiles-view-test.js
+++ b/tests/acceptance/profiles-view-test.js
@@ -1,6 +1,10 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from "ember-qunit";
-import FactoryGuy, { makeList, mockFindAll, setupFactoryGuy } from 'ember-data-factory-guy';
+import FactoryGuy, {
+  makeList,
+  mockFindAll,
+  setupFactoryGuy
+} from 'ember-data-factory-guy';
 import { visit } from '@ember/test-helpers';
 
 module('Acceptance | Profiles View', function(hooks) {

--- a/tests/acceptance/user-search-test.js
+++ b/tests/acceptance/user-search-test.js
@@ -1,5 +1,11 @@
 import { module, test } from 'qunit';
-import { buildList, make, makeList, mockQuery, setupFactoryGuy } from 'ember-data-factory-guy';
+import {
+  buildList,
+  make,
+  makeList,
+  mockQuery,
+  setupFactoryGuy
+} from 'ember-data-factory-guy';
 import { setupApplicationTest } from "ember-qunit";
 import { click, fillIn, visit } from '@ember/test-helpers';
 

--- a/tests/acceptance/users-delete-test.js
+++ b/tests/acceptance/users-delete-test.js
@@ -1,6 +1,11 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { makeList, mockDelete, mockFindAll, setupFactoryGuy } from 'ember-data-factory-guy';
+import {
+  makeList,
+  mockDelete,
+  mockFindAll,
+  setupFactoryGuy
+} from 'ember-data-factory-guy';
 import { visit, click } from '@ember/test-helpers';
 
 module('Acceptance | Users Delete', function(hooks) {

--- a/tests/acceptance/users-view-test.js
+++ b/tests/acceptance/users-view-test.js
@@ -1,6 +1,11 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { buildList, makeList, mockFindAll, setupFactoryGuy } from 'ember-data-factory-guy';
+import {
+  buildList,
+  makeList,
+  mockFindAll,
+  setupFactoryGuy
+} from 'ember-data-factory-guy';
 import { visit } from '@ember/test-helpers';
 
 module('Acceptance | Users View', function(hooks) {

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,11 +1,11 @@
-import Ember from 'ember';
+import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 let App;
 
-App = Ember.Application.extend({
+App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/components/dude-translator.js
+++ b/tests/dummy/app/components/dude-translator.js
@@ -1,12 +1,13 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 
 /**
  * Dude Translator
  */
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['translator'],
 
-  translation: Ember.computed('original', function() {
+  translation: computed('original', function() {
     return this.get('original') + ' dude';
   })
 

--- a/tests/dummy/app/components/profile-list.js
+++ b/tests/dummy/app/components/profile-list.js
@@ -1,2 +1,2 @@
-import Ember from 'ember';
-export default Ember.Component.extend({});
+import Component from '@ember/component';
+export default Component.extend({});

--- a/tests/dummy/app/components/single-employee.js
+++ b/tests/dummy/app/components/single-employee.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['employee'],
 //  didInsertElement() {
 //    this._super(...arguments);

--- a/tests/dummy/app/components/single-user.js
+++ b/tests/dummy/app/components/single-user.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['user'],
 
   actions: {

--- a/tests/dummy/app/components/user-list.js
+++ b/tests/dummy/app/components/user-list.js
@@ -1,2 +1,2 @@
-import Ember from 'ember';
-export default Ember.Component.extend();
+import Component from '@ember/component';
+export default Component.extend();

--- a/tests/dummy/app/components/user-search.js
+++ b/tests/dummy/app/components/user-search.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
 
   actions: {
 

--- a/tests/dummy/app/controllers/profiles.js
+++ b/tests/dummy/app/controllers/profiles.js
@@ -1,2 +1,2 @@
-import Ember from 'ember';
-export default Ember.Controller.extend();
+import Controller from '@ember/controller';
+export default Controller.extend();

--- a/tests/dummy/app/controllers/search.js
+++ b/tests/dummy/app/controllers/search.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
 
   actions: {
     userSearch(name) {

--- a/tests/dummy/app/controllers/user.js
+++ b/tests/dummy/app/controllers/user.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
-export default Ember.Controller.extend({
+import Controller from '@ember/controller';
+export default Controller.extend({
 
   actions: {
     createProject(user, title) {

--- a/tests/dummy/app/controllers/users.js
+++ b/tests/dummy/app/controllers/users.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
 
   actions: {
     deleteUser(user) {

--- a/tests/dummy/app/models/big-hat.js
+++ b/tests/dummy/app/models/big-hat.js
@@ -1,5 +1,5 @@
 import Hat from './hat';
-import {hasMany} from 'ember-data/relationships';
+import { hasMany } from 'ember-data/relationships';
 
 export default Hat.extend({
   materials: hasMany('soft-material', {async: false})

--- a/tests/dummy/app/models/comic-book.js
+++ b/tests/dummy/app/models/comic-book.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {hasMany, belongsTo} from 'ember-data/relationships';
+import { hasMany, belongsTo } from 'ember-data/relationships';
 
 export default Model.extend({
   name: attr('string'),

--- a/tests/dummy/app/models/company.js
+++ b/tests/dummy/app/models/company.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {hasMany, belongsTo} from 'ember-data/relationships';
+import { hasMany, belongsTo } from 'ember-data/relationships';
 
 export default Model.extend({
   type: attr('string', { defaultValue: 'Company' }),

--- a/tests/dummy/app/models/department-employment.js
+++ b/tests/dummy/app/models/department-employment.js
@@ -1,6 +1,6 @@
 import attr from 'ember-data/attr';
 import Fragment from 'ember-data-model-fragments/fragment';
-import {fragment} from 'ember-data-model-fragments/attributes';
+import { fragment } from 'ember-data-model-fragments/attributes';
 
 export default Fragment.extend({
   startDate: attr('date'),

--- a/tests/dummy/app/models/department.js
+++ b/tests/dummy/app/models/department.js
@@ -1,6 +1,6 @@
 import attr from 'ember-data/attr';
 import Fragment from 'ember-data-model-fragments/fragment';
-import {fragmentArray} from 'ember-data-model-fragments/attributes';
+import { fragmentArray } from 'ember-data-model-fragments/attributes';
 
 export default Fragment.extend({
   name: attr('string'),

--- a/tests/dummy/app/models/employee.js
+++ b/tests/dummy/app/models/employee.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {array, fragment, fragmentArray} from 'ember-data-model-fragments/attributes';
+import { array, fragment, fragmentArray } from 'ember-data-model-fragments/attributes';
 
 export default Model.extend({
   designation: fragment('name'),

--- a/tests/dummy/app/models/entry-type.js
+++ b/tests/dummy/app/models/entry-type.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {hasMany} from 'ember-data/relationships';
+import { hasMany } from 'ember-data/relationships';
 
 export default Model.extend({
   name: attr('string'),

--- a/tests/dummy/app/models/entry.js
+++ b/tests/dummy/app/models/entry.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {belongsTo} from 'ember-data/relationships';
+import { belongsTo } from 'ember-data/relationships';
 
 export default Model.extend({
   name: attr('string'),

--- a/tests/dummy/app/models/fluffy-material.js
+++ b/tests/dummy/app/models/fluffy-material.js
@@ -1,5 +1,5 @@
 import Material from './material';
-import {belongsTo} from 'ember-data/relationships';
+import { belongsTo } from 'ember-data/relationships';
 
 export default Material.extend({
   hat:  belongsTo('hat', {async: false, inverse: 'fluffyMaterials', polymorphic: true})

--- a/tests/dummy/app/models/hat.js
+++ b/tests/dummy/app/models/hat.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {hasMany, belongsTo} from 'ember-data/relationships';
+import { hasMany, belongsTo } from 'ember-data/relationships';
 
 export default Model.extend({
   type: attr('string'),

--- a/tests/dummy/app/models/manager.js
+++ b/tests/dummy/app/models/manager.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
-import {hasMany, belongsTo} from 'ember-data/relationships';
-import {fragment} from 'ember-data-model-fragments/attributes';
+import { hasMany, belongsTo } from 'ember-data/relationships';
+import { fragment } from 'ember-data-model-fragments/attributes';
 
 export default Model.extend({
   name: fragment('name'),

--- a/tests/dummy/app/models/outfit.js
+++ b/tests/dummy/app/models/outfit.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {hasMany, belongsTo} from 'ember-data/relationships';
+import { hasMany, belongsTo } from 'ember-data/relationships';
 
 export default Model.extend({
   name: attr('string'),

--- a/tests/dummy/app/models/person.js
+++ b/tests/dummy/app/models/person.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {hasMany, belongsTo} from 'ember-data/relationships';
+import { hasMany, belongsTo } from 'ember-data/relationships';
 
 export default Model.extend({
   type: attr('string'),

--- a/tests/dummy/app/models/profile.js
+++ b/tests/dummy/app/models/profile.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {belongsTo} from 'ember-data/relationships';
+import { belongsTo } from 'ember-data/relationships';
 
 export default Model.extend({
   created_at: attr('date'),

--- a/tests/dummy/app/models/project.js
+++ b/tests/dummy/app/models/project.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {hasMany, belongsTo} from 'ember-data/relationships';
+import { hasMany, belongsTo } from 'ember-data/relationships';
 
 export default Model.extend({
   title: attr('string'),

--- a/tests/dummy/app/models/property.js
+++ b/tests/dummy/app/models/property.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {hasMany, belongsTo} from 'ember-data/relationships';
+import { hasMany, belongsTo } from 'ember-data/relationships';
 
 export default Model.extend({
   name: attr('string'),

--- a/tests/dummy/app/models/salary.js
+++ b/tests/dummy/app/models/salary.js
@@ -1,6 +1,6 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {array} from 'ember-data-model-fragments/attributes';
+import { array } from 'ember-data-model-fragments/attributes';
 
 export default Model.extend({
   income: attr('number'),

--- a/tests/dummy/app/models/small-company.js
+++ b/tests/dummy/app/models/small-company.js
@@ -1,6 +1,6 @@
 import Company from './company';
 import attr from 'ember-data/attr';
-import {hasMany, belongsTo} from 'ember-data/relationships';
+import { hasMany, belongsTo } from 'ember-data/relationships';
 
 export default Company.extend({
   type: attr('string', { defaultValue: 'SmallCompany' }),

--- a/tests/dummy/app/models/small-hat.js
+++ b/tests/dummy/app/models/small-hat.js
@@ -1,5 +1,5 @@
 import Hat from './hat';
-import {hasMany} from 'ember-data/relationships';
+import { hasMany } from 'ember-data/relationships';
 
 export default Hat.extend({
   materials: hasMany('material', {polymorphic: true})

--- a/tests/dummy/app/models/soft-material.js
+++ b/tests/dummy/app/models/soft-material.js
@@ -1,5 +1,5 @@
 import Material from './material';
-import {belongsTo} from 'ember-data/relationships';
+import { belongsTo } from 'ember-data/relationships';
 
 export default Material.extend({
   hat: belongsTo('big-hat', { async: false })

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import {hasMany, belongsTo} from 'ember-data/relationships';
+import { hasMany, belongsTo } from 'ember-data/relationships';
 
 export default Model.extend({
   name: attr('string'),
@@ -12,7 +12,7 @@ export default Model.extend({
   projects: hasMany('project', { async: false }),
   hats: hasMany('hat', { async: false, polymorphic: true }),
 
-  funnyName: Ember.computed("name", function() {
+  funnyName: computed("name", function() {
     return "funny " + this.get('name');
   })
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,3 +1,3 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend();
+export default Route.extend();

--- a/tests/dummy/app/routes/cats.js
+++ b/tests/dummy/app/routes/cats.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model: function() {
     return this.store.findAll('cat');
   }

--- a/tests/dummy/app/routes/employees.js
+++ b/tests/dummy/app/routes/employees.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
 });

--- a/tests/dummy/app/routes/profiles.js
+++ b/tests/dummy/app/routes/profiles.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model: function() {
     return this.store.findAll('profile');
   }

--- a/tests/dummy/app/routes/search.js
+++ b/tests/dummy/app/routes/search.js
@@ -1,3 +1,3 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend();
+export default Route.extend();

--- a/tests/dummy/app/routes/search/results.js
+++ b/tests/dummy/app/routes/search/results.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
 
   model(params) {
     return this.store.query('user', { name: params.name }).catch(e => e);

--- a/tests/dummy/app/routes/user.js
+++ b/tests/dummy/app/routes/user.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model: function(params) {
     return this.store.findRecord('user', params.user_id).catch(()=>null);
   }

--- a/tests/dummy/app/routes/users.js
+++ b/tests/dummy/app/routes/users.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model: function() {
     return this.store.findAll('user');
   }

--- a/tests/dummy/app/scenarios/main.js
+++ b/tests/dummy/app/scenarios/main.js
@@ -1,4 +1,4 @@
-import {Scenario} from 'ember-data-factory-guy';
+import { Scenario } from 'ember-data-factory-guy';
 
 import Users from './users';
 //import UsersB from './usersB';

--- a/tests/dummy/app/scenarios/users.js
+++ b/tests/dummy/app/scenarios/users.js
@@ -1,4 +1,4 @@
-import {Scenario} from 'ember-data-factory-guy';
+import { Scenario } from 'ember-data-factory-guy';
 
 export default class extends Scenario {
   run() {

--- a/tests/dummy/app/scenarios/usersB.js
+++ b/tests/dummy/app/scenarios/usersB.js
@@ -1,4 +1,4 @@
-import {Scenario} from 'ember-data-factory-guy';
+import { Scenario } from 'ember-data-factory-guy';
 
 export default class extends Scenario {
   run() {

--- a/tests/dummy/app/serializers/name.js
+++ b/tests/dummy/app/serializers/name.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
+import { decamelize } from '@ember/string';
 import DS from 'ember-data';
 
 export default DS.RESTSerializer.extend({
   keyForAttribute(attr) {
-    return Ember.String.decamelize(attr);
+    return decamelize(attr);
   }
 });

--- a/tests/dummy/app/tests/factories/dog.js
+++ b/tests/dummy/app/tests/factories/dog.js
@@ -1,5 +1,5 @@
 import FactoryGuy from 'ember-data-factory-guy';
-import {sound as mooSound} from '../helpers/moo';
+import { sound as mooSound } from '../helpers/moo';
 
 const defaultVolume = "Normal";
 

--- a/tests/dummy/app/transforms/object.js
+++ b/tests/dummy/app/transforms/object.js
@@ -1,18 +1,18 @@
+import { isEmpty, typeOf } from '@ember/utils';
 import DS from 'ember-data';
-import Ember from 'ember';
 
 export default DS.Transform.extend({
   serialize: function(value) {
     return value ? JSON.stringify(value) : '{}';
   },
   deserialize: function(value) {
-    if (Ember.isEmpty(value)) {
+    if (isEmpty(value)) {
       return {};
     }
-    if (Ember.typeOf(value) === "object") {
+    if (typeOf(value) === "object") {
       return value;
     }
-    if (Ember.typeOf(value) === 'string') {
+    if (typeOf(value) === 'string') {
       return JSON.parse(value);
     }
   }

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,10 +1,8 @@
+import { Promise } from 'rsvp';
 import { module } from 'qunit';
-import Ember from 'ember';
 import FactoryGuy from 'ember-data-factory-guy';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-
-const {RSVP: {Promise}} = Ember;
 
 export default function(name, options = {}) {
   module(name, {

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,12 +1,13 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
+import { merge } from '@ember/polyfills';
 import Application from '../../app';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
-  return Ember.run(() => {
+  return run(() => {
     let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();

--- a/tests/helpers/utility-methods.js
+++ b/tests/helpers/utility-methods.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { typeOf } from '@ember/utils';
 import FactoryGuy, { manualSetup } from 'ember-data-factory-guy';
 import DS from 'ember-data';
 import DRFAdapter from 'ember-django-adapter/adapters/drf';
@@ -25,7 +25,7 @@ import { ActiveModelSerializer } from 'active-model-adapter';
 //  }
 //};
 
-// custom serializer options for the various models 
+// custom serializer options for the various models
 // which are applied to the currently testing  model's serializer ( JSONAPI, REST, ActiveModel, etc )
 const serializerOptions = {
   'entry-type': {
@@ -66,7 +66,7 @@ const serializerOptions = {
 //function setupCustomAdapter(container, adapterType, options) {
 //  let store = container.lookup('service:store');
 //  let modelAdapter = container.lookup('adapter:' + adapterType);
-//  if (Ember.typeOf(options) === 'array') {
+//  if (typeOf(options) === 'array') {
 //    modelAdapter.reopen.apply(modelAdapter, options);
 //  } else {
 //    modelAdapter.reopen(options);
@@ -78,7 +78,7 @@ const serializerOptions = {
 function setupCustomSerializer(container, serializerType, options) {
   let store = container.lookup('service:store');
   let modelSerializer = container.lookup('serializer:' + serializerType);
-  if (Ember.typeOf(options) === 'array') {
+  if (typeOf(options) === 'array') {
     modelSerializer.reopen.apply(modelSerializer, options);
   } else {
     modelSerializer.reopen(options);

--- a/tests/unit/active-model-adapter-test.js
+++ b/tests/unit/active-model-adapter-test.js
@@ -1,7 +1,12 @@
+import { dasherize } from '@ember/string';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import Ember from 'ember';
-import FactoryGuy, { build, buildList, mockCreate } from 'ember-data-factory-guy';
+import FactoryGuy, {
+  build,
+  buildList,
+  mockCreate
+} from 'ember-data-factory-guy';
 import SharedCommonBehavior from './shared-common-behaviour';
 import SharedAdapterBehaviour from './shared-adapter-behaviour';
 import { inlineSetup } from '../helpers/utility-methods';
@@ -34,11 +39,11 @@ module(serializer, function(hooks) {
 
       mockCreate('profile').returns({attrs: {camel_case_description: customDescription}});
 
-      let profile = Ember.run(() => FactoryGuy.store.createRecord('profile', {
+      let profile = run(() => FactoryGuy.store.createRecord('profile', {
         camel_case_description: 'description'
       }));
 
-      await Ember.run(async () => profile.save());
+      await run(async () => profile.save());
 
       assert.ok(profile.get('camelCaseDescription') === customDescription);
     });
@@ -236,9 +241,9 @@ module(serializer, function(hooks) {
       let serializer = FactoryGuy.store.serializerFor('application');
 
       let savedKeyForAttributeFn = serializer.keyForAttribute;
-      serializer.keyForAttribute = Ember.String.dasherize;
+      serializer.keyForAttribute = dasherize;
       let savedKeyForRelationshipFn = serializer.keyForRelationship;
-      serializer.keyForRelationship = Ember.String.dasherize;
+      serializer.keyForRelationship = dasherize;
 
       let buildJson = build('profile', 'with_bat_man');
       buildJson.unwrap();

--- a/tests/unit/drf-adapter-test.js
+++ b/tests/unit/drf-adapter-test.js
@@ -1,7 +1,11 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import FactoryGuy, { build, buildList, mockQuery } from 'ember-data-factory-guy';
+import FactoryGuy, {
+  build,
+  buildList,
+  mockQuery
+} from 'ember-data-factory-guy';
 import SharedAdapterBehaviour from './shared-adapter-behaviour';
 import { inlineSetup } from '../helpers/utility-methods';
 import { isEquivalent } from 'ember-data-factory-guy/utils/helper-functions';
@@ -47,7 +51,7 @@ module(serializer, function(hooks) {
     // drf serializer takes the previous and next and extracts the page number
     // so this needed it's own test
     test("with proxy payload", function(assert) {
-      Ember.run(() => {
+      run(() => {
         let done = assert.async();
         let json = buildList('profile', 2).add({meta: {previous: 'http://dude?page=1', next: 'http://dude?page=3'}});
         mockQuery('profile', {}).returns({json});

--- a/tests/unit/factory-guy-test.js
+++ b/tests/unit/factory-guy-test.js
@@ -1,7 +1,8 @@
+import { run } from '@ember/runloop';
+import { A } from '@ember/array';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import DS from 'ember-data';
-import Ember from 'ember';
 import FactoryGuy, {
   attributesFor, build, buildList, make, makeList, makeNew
 } from 'ember-data-factory-guy';
@@ -11,8 +12,6 @@ import { inlineSetup } from '../helpers/utility-methods';
 import User from 'dummy/models/user';
 import Name from 'dummy/models/name';
 import RequestManager from 'ember-data-factory-guy/mocks/request-manager';
-
-const A = Ember.A;
 
 module('FactoryGuy', function(hooks) {
   setupTest(hooks);
@@ -56,7 +55,7 @@ module('FactoryGuy', function(hooks) {
   });
 
   test("#resetDefinitions resets the model definition", function(assert) {
-    Ember.run(function() {
+    run(function() {
       let project = make('project');
       make('user', {projects: [project]});
 
@@ -839,7 +838,7 @@ module('FactoryGuy', function(hooks) {
 
     test("removes id for model fragmentArray attribute", function(assert) {
       let json = FactoryGuy.buildRaw({name: 'employee', traits: ['with_department_employments']});
-      let ids = Ember.A(json.departmentEmployments.map((obj) => obj.id)).compact();
+      let ids = A(json.departmentEmployments.map((obj) => obj.id)).compact();
       assert.deepEqual(ids, []);
     });
   });

--- a/tests/unit/get-pretenter-test.js
+++ b/tests/unit/get-pretenter-test.js
@@ -1,6 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { mock, setupFactoryGuy, getPretender } from 'ember-data-factory-guy';
+import {
+  mock,
+  setupFactoryGuy,
+  getPretender
+} from 'ember-data-factory-guy';
 import Pretender from 'pretender'
 
 module('Unit | getPretender', function(hooks) {

--- a/tests/unit/json-adapter-test.js
+++ b/tests/unit/json-adapter-test.js
@@ -1,7 +1,11 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import FactoryGuy, { build, buildList, mockFindRecord } from 'ember-data-factory-guy';
+import FactoryGuy, {
+  build,
+  buildList,
+  mockFindRecord
+} from 'ember-data-factory-guy';
 import SharedCommonBehavior from './shared-common-behaviour';
 import SharedAdapterBehaviour from './shared-adapter-behaviour';
 import { inlineSetup } from '../helpers/utility-methods';
@@ -27,7 +31,7 @@ module(serializer, function(hooks) {
   module('#mockFindRecord custom', function() {
 
     test("when returns json (plain) is used", function(assert) {
-      Ember.run(() => {
+      run(() => {
         let done      = assert.async(),
             json      = {id: 1, description: 'the desc'},
             mock      = mockFindRecord('profile').returns({json}),

--- a/tests/unit/jsonapi-adapter-test.js
+++ b/tests/unit/jsonapi-adapter-test.js
@@ -1,6 +1,7 @@
+import { underscore } from '@ember/string';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import Ember from 'ember';
 import FactoryGuy, {
   build,
   buildList,
@@ -35,7 +36,7 @@ module(serializer, function(hooks) {
   module('#mockFindRecord custom', function() {
 
     test("when returns json (plain) is used", function(assert) {
-      Ember.run(() => {
+      run(() => {
         let done      = assert.async(),
             json      = {data: {id: 1, type: 'profile', attributes: {description: 'the desc'}}},
             mock      = mockFindRecord('profile').returns({json}),
@@ -53,7 +54,7 @@ module(serializer, function(hooks) {
   module('#mockCreate custom', function() {
 
     test("match belongsTo with custom payloadKeyFromModelName function", function(assert) {
-      Ember.run(() => {
+      run(() => {
         let done = assert.async();
 
         let entryType = make('entry-type');
@@ -68,7 +69,7 @@ module(serializer, function(hooks) {
     });
 
     test("match hasMany with custom payloadKeyFromModelName function", function(assert) {
-      Ember.run(() => {
+      run(() => {
         let done = assert.async();
 
         let entry = make('entry');
@@ -623,8 +624,8 @@ module(serializer, function(hooks) {
     test("using custom serialize keys function for transforming attributes and relationship keys", function(assert) {
       let serializer = FactoryGuy.store.serializerFor('profile');
 
-      serializer.keyForAttribute = Ember.String.underscore;
-      serializer.keyForRelationship = Ember.String.underscore;
+      serializer.keyForAttribute = underscore;
+      serializer.keyForRelationship = underscore;
 
       let json = build('profile', 'with_bat_man');
       json.unwrap();

--- a/tests/unit/mocks/mock-any-test.js
+++ b/tests/unit/mocks/mock-any-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import $ from 'jquery';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { mock } from 'ember-data-factory-guy';
@@ -32,7 +32,7 @@ module('MockAny', function(hooks) {
           mockOpts     = Object.assign({responseText}, callOpts);
 
     mock(mockOpts);
-    let json = await Ember.$.ajax(callOpts);
+    let json = await $.ajax(callOpts);
     assert.deepEqual(JSON.parse(json), responseText);
   });
 
@@ -46,7 +46,7 @@ module('MockAny', function(hooks) {
           mockOpts     = Object.assign({responseText}, callOpts);
 
     mock(mockOpts);
-    let json = await Ember.$.ajax(callOpts);
+    let json = await $.ajax(callOpts);
     assert.deepEqual(JSON.parse(json), responseText);
   });
 
@@ -57,12 +57,12 @@ module('MockAny', function(hooks) {
           whatsUpDoc = {whats: 'up doc'};
 
     let theMock = mock({url, type}).withParams(whatsUp).returns(whatsUp),
-        json    = await Ember.$.ajax({type, url, data: whatsUp});
+        json    = await $.ajax({type, url, data: whatsUp});
 
     assert.deepEqual(JSON.parse(json), whatsUp, 'returns json for url with params #1');
 
     theMock.withParams(whatsUpDoc).returns(whatsUpDoc);
-    json = await Ember.$.ajax({type, url, data: whatsUpDoc});
+    json = await $.ajax({type, url, data: whatsUpDoc});
     assert.deepEqual(JSON.parse(json), whatsUpDoc, 'returns json for url matching params #2');
   });
 
@@ -73,12 +73,12 @@ module('MockAny', function(hooks) {
           whatsUpDoc = {whats: 'up doc'};
 
     let theMock = mock({url, type}).withParams(whatsUp).returns(whatsUp),
-        json    = await Ember.$.ajax({type, url, data: whatsUp});
+        json    = await $.ajax({type, url, data: whatsUp});
 
     assert.deepEqual(JSON.parse(json), whatsUp, 'returns json for url with params #1');
 
     theMock.withParams(whatsUpDoc).returns(whatsUpDoc);
-    json = await Ember.$.ajax({type, url, data: whatsUpDoc});
+    json = await $.ajax({type, url, data: whatsUpDoc});
     assert.deepEqual(JSON.parse(json), whatsUpDoc, 'returns json for url matching params #2');
   });
 
@@ -90,11 +90,11 @@ module('MockAny', function(hooks) {
 
     let theMock = mock({url}).returns(whatsUp);
 
-    let json = await Ember.$.ajax({type, url});
+    let json = await $.ajax({type, url});
     assert.deepEqual(JSON.parse(json), whatsUp, 'returns json that is set');
 
     theMock.returns(whatsUpDoc);
-    json = await Ember.$.ajax({type, url});
+    json = await $.ajax({type, url});
     assert.deepEqual(JSON.parse(json), whatsUpDoc, 'returns next json that is set');
   });
 
@@ -105,11 +105,11 @@ module('MockAny', function(hooks) {
           whatsUpDoc = {whats: 'up doc'};
 
     let theMock = mock({url}).withParams(whatsUp).returns(whatsUp);
-    let json = await Ember.$.ajax({type, url, data: whatsUp});
+    let json = await $.ajax({type, url, data: whatsUp});
     assert.deepEqual(JSON.parse(json), whatsUp, 'returns json for url with params #1');
 
     theMock.withParams(whatsUpDoc).returns(whatsUpDoc);
-    json = await Ember.$.ajax({type, url, data: whatsUpDoc});
+    json = await $.ajax({type, url, data: whatsUpDoc});
     assert.deepEqual(JSON.parse(json), whatsUpDoc, 'returns json for url matching params #2');
   });
 
@@ -120,7 +120,7 @@ module('MockAny', function(hooks) {
           responseText = {dude: 'dude'};
 
     mock({url, type, data}).returns(responseText);
-    const json = await Ember.$.ajax({type, url, data});
+    const json = await $.ajax({type, url, data});
 
     assert.deepEqual(JSON.parse(json), responseText, 'returns json for url with params #1');
   });
@@ -132,12 +132,12 @@ module('MockAny', function(hooks) {
           whatsUpDoc = {whats: 'up doc'};
 
     let theMock = mock({url, type}).withParams(whatsUp).returns(whatsUp),
-        json    = await Ember.$.ajax({type, url, data: whatsUp});
+        json    = await $.ajax({type, url, data: whatsUp});
 
     assert.deepEqual(JSON.parse(json), whatsUp, 'returns json for url with params #1');
 
     theMock.withParams(whatsUpDoc).returns(whatsUpDoc);
-    json = await Ember.$.ajax({type, url, data: whatsUpDoc});
+    json = await $.ajax({type, url, data: whatsUpDoc});
     assert.deepEqual(JSON.parse(json), whatsUpDoc, 'returns json for url matching params #2');
   });
 });

--- a/tests/unit/mocks/mock-create-test.js
+++ b/tests/unit/mocks/mock-create-test.js
@@ -1,7 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Model from 'ember-data/model';
-import FactoryGuy, { build, makeNew, mockCreate } from 'ember-data-factory-guy';
+import FactoryGuy, {
+  build,
+  makeNew,
+  mockCreate
+} from 'ember-data-factory-guy';
 import { run } from '@ember/runloop';
 import { inlineSetup } from '../../helpers/utility-methods';
 import sinon from 'sinon';

--- a/tests/unit/mocks/mock-delete-test.js
+++ b/tests/unit/mocks/mock-delete-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import FactoryGuy, { make, mockDelete } from 'ember-data-factory-guy';
@@ -33,7 +33,7 @@ module('MockDelete', function(hooks) {
     const consoleStub = sinon.spy(console, 'log'),
           mock        = mockDelete(profile);
 
-    await Ember.run(async () => profile.destroyRecord());
+    await run(async () => profile.destroyRecord());
 
     let response     = JSON.parse(mock.actualResponseJson()),
         expectedArgs = [

--- a/tests/unit/mocks/mock-find-all-test.js
+++ b/tests/unit/mocks/mock-find-all-test.js
@@ -1,7 +1,13 @@
-import Ember from 'ember';
+import $ from 'jquery';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import FactoryGuy, { make, buildList, mockFindAll, mockQuery } from 'ember-data-factory-guy';
+import FactoryGuy, {
+  make,
+  buildList,
+  mockFindAll,
+  mockQuery
+} from 'ember-data-factory-guy';
 import { inlineSetup } from '../../helpers/utility-methods';
 import sinon from 'sinon';
 import RequestManager from 'ember-data-factory-guy/mocks/request-manager';
@@ -37,7 +43,7 @@ module('MockFindAll', function(hooks) {
     const consoleStub = sinon.spy(console, 'log'),
           mock        = mockFindAll('profile');
 
-    await Ember.run(async () => FactoryGuy.store.findAll('profile'));
+    await run(async () => FactoryGuy.store.findAll('profile'));
 
     let response     = JSON.parse(mock.actualResponseJson()),
         expectedArgs = [
@@ -53,8 +59,8 @@ module('MockFindAll', function(hooks) {
 
     const queryParams = {include: 'company'};
     mock.withParams(queryParams);
-    await Ember.run(async () => FactoryGuy.store.findAll('profile', queryParams));
-    expectedArgs[4] = `/profiles?${Ember.$.param(queryParams)}`;
+    await run(async () => FactoryGuy.store.findAll('profile', queryParams));
+    expectedArgs[4] = `/profiles?${$.param(queryParams)}`;
 
     assert.deepEqual(consoleStub.getCall(1).args, expectedArgs, 'with query params');
 

--- a/tests/unit/mocks/mock-find-record-test.js
+++ b/tests/unit/mocks/mock-find-record-test.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import $ from 'jquery';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import FactoryGuy, { build, mockFindRecord } from 'ember-data-factory-guy';
@@ -27,7 +28,7 @@ module('MockFindRecord', function(hooks) {
     const consoleStub = sinon.spy(console, 'log'),
           mock        = mockFindRecord('profile');
 
-    await Ember.run(async () => FactoryGuy.store.findRecord('profile', 1));
+    await run(async () => FactoryGuy.store.findRecord('profile', 1));
 
     let response     = JSON.parse(mock.actualResponseJson()),
         expectedArgs = [
@@ -43,8 +44,8 @@ module('MockFindRecord', function(hooks) {
 
     const queryParams = {include: 'company'};
     mock.withParams(queryParams);
-    await Ember.run(async () => FactoryGuy.store.findRecord('profile', 1, queryParams));
-    expectedArgs[4] = `/profiles/1?${Ember.$.param(queryParams)}`;
+    await run(async () => FactoryGuy.store.findRecord('profile', 1, queryParams));
+    expectedArgs[4] = `/profiles/1?${$.param(queryParams)}`;
 
     assert.deepEqual(consoleStub.getCall(1).args, expectedArgs, 'with query params');
 
@@ -97,7 +98,7 @@ module('MockFindRecord', function(hooks) {
   module('#fails', function() {
 
     test("with errors in response", function(assert) {
-      Ember.run(() => {
+      run(() => {
         const done     = assert.async(),
               response = {errors: {description: ['bad']}},
               mock     = mockFindRecord('profile').fails({response});

--- a/tests/unit/mocks/mock-links-test.js
+++ b/tests/unit/mocks/mock-links-test.js
@@ -1,6 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { buildList, make, makeList, mockLinks } from 'ember-data-factory-guy';
+import {
+  buildList,
+  make,
+  makeList,
+  mockLinks
+} from 'ember-data-factory-guy';
 import { inlineSetup } from '../../helpers/utility-methods';
 
 const serializerType = '-json-api';

--- a/tests/unit/mocks/mock-query-record-test.js
+++ b/tests/unit/mocks/mock-query-record-test.js
@@ -1,7 +1,13 @@
-import Ember from 'ember';
+import $ from 'jquery';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import FactoryGuy, { build, make, makeList, mockQueryRecord } from 'ember-data-factory-guy';
+import FactoryGuy, {
+  build,
+  make,
+  makeList,
+  mockQueryRecord
+} from 'ember-data-factory-guy';
 import { inlineSetup } from '../../helpers/utility-methods';
 import sinon from 'sinon';
 
@@ -25,7 +31,7 @@ module('MockQueryRecord', function(hooks) {
           consoleStub = sinon.spy(console, 'log'),
           mock        = mockQueryRecord('profile').withParams(queryParams);
 
-    await Ember.run(async () => FactoryGuy.store.queryRecord('profile', queryParams));
+    await run(async () => FactoryGuy.store.queryRecord('profile', queryParams));
 
     let response     = JSON.parse(mock.actualResponseJson()),
         expectedArgs = [
@@ -33,7 +39,7 @@ module('MockQueryRecord', function(hooks) {
           "MockQueryRecord",
           "GET",
           "[200]",
-          `/profiles?${Ember.$.param(queryParams)}`,
+          `/profiles?${$.param(queryParams)}`,
           response
         ];
 
@@ -93,7 +99,7 @@ module('MockQueryRecord', function(hooks) {
   });
 
   test("using fails makes the request fail", function(assert) {
-    Ember.run(() => {
+    run(() => {
       let done = assert.async();
 
       mockQueryRecord('user').fails();
@@ -114,9 +120,9 @@ module('MockQueryRecord', function(hooks) {
     let {headers} = handler.getResponse();
     assert.deepEqual(headers, {'X-Testing': 'absolutely'});
 
-    Ember.$(document).ajaxComplete(function(event, xhr) {
+    $(document).ajaxComplete(function(event, xhr) {
       assert.equal(xhr.getResponseHeader('X-Testing'), 'absolutely');
-      Ember.$(document).off('ajaxComplete');
+      $(document).off('ajaxComplete');
       done();
     });
 

--- a/tests/unit/mocks/mock-query-test.js
+++ b/tests/unit/mocks/mock-query-test.js
@@ -1,7 +1,12 @@
-import Ember from 'ember';
+import $ from 'jquery';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import FactoryGuy, { make, buildList, mockQuery } from 'ember-data-factory-guy';
+import FactoryGuy, {
+  make,
+  buildList,
+  mockQuery
+} from 'ember-data-factory-guy';
 import { inlineSetup } from '../../helpers/utility-methods';
 import sinon from 'sinon';
 
@@ -24,7 +29,7 @@ module('MockQuery', function(hooks) {
           consoleStub = sinon.spy(console, 'log'),
           mock        = mockQuery('profile').withParams(queryParams);
 
-    await Ember.run(async () => FactoryGuy.store.query('profile', queryParams));
+    await run(async () => FactoryGuy.store.query('profile', queryParams));
 
     let response     = JSON.parse(mock.actualResponseJson()),
         expectedArgs = [
@@ -32,7 +37,7 @@ module('MockQuery', function(hooks) {
           "MockQuery",
           "GET",
           "[200]",
-          `/profiles?${Ember.$.param(queryParams)}`,
+          `/profiles?${$.param(queryParams)}`,
           response
         ];
 

--- a/tests/unit/mocks/mock-request-test.js
+++ b/tests/unit/mocks/mock-request-test.js
@@ -1,6 +1,6 @@
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import Ember from 'ember';
 import FactoryGuy, {
   make, build, mockFindAll, mockQueryRecord, mockUpdate
 } from 'ember-data-factory-guy';
@@ -62,7 +62,7 @@ module('MockRequest', function(hooks) {
   module('#timeCalled', function() {
 
     test("can verify how many times a queryRecord call was mocked", async function(assert) {
-      return Ember.run(async () => {
+      return run(async () => {
         const mock = mockQueryRecord('company', {}).returns({json: build('company')});
 
         await FactoryGuy.store.queryRecord('company', {});
@@ -72,7 +72,7 @@ module('MockRequest', function(hooks) {
     });
 
     test("can verify how many times a findAll call was mocked", async function(assert) {
-      return Ember.run(async () => {
+      return run(async () => {
         const mock = mockFindAll('company');
 
         await FactoryGuy.store.findAll('company');
@@ -85,11 +85,11 @@ module('MockRequest', function(hooks) {
       const company = make('company'),
             mock    = mockUpdate(company);
 
-      Ember.run(() => company.set('name', 'ONE'));
-      await Ember.run(async () => company.save());
+      run(() => company.set('name', 'ONE'));
+      await run(async () => company.save());
 
-      Ember.run(() => company.set('name', 'TWO'));
-      await Ember.run(async () => company.save());
+      run(() => company.set('name', 'TWO'));
+      await run(async () => company.save());
 
       assert.equal(mock.timesCalled, 2);
     });
@@ -98,7 +98,7 @@ module('MockRequest', function(hooks) {
   module('#disable, #enable, and #destroy', function() {
 
     test("can enable, disable, and destroy mock", async function(assert) {
-      return Ember.run(async () => {
+      return run(async () => {
         let json1 = build('user'),
             json2 = build('user'),
             mock1 = mockQueryRecord('user', {id: 1}).returns({json: json1});

--- a/tests/unit/mocks/mock-update-test.js
+++ b/tests/unit/mocks/mock-update-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import FactoryGuy, { make, mockUpdate } from 'ember-data-factory-guy';
@@ -38,7 +38,7 @@ module('MockUpdate', function(hooks) {
           profile     = make('profile'),
           mock        = mockUpdate(profile);
 
-    await Ember.run(async () => profile.save());
+    await run(async () => profile.save());
 
     let response     = JSON.parse(mock.getResponse().responseText),
         expectedArgs = [

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -1,7 +1,11 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import FactoryGuy, { make, setupFactoryGuy, mockFindRecord } from 'ember-data-factory-guy';
+import FactoryGuy, {
+  make,
+  setupFactoryGuy,
+  mockFindRecord
+} from 'ember-data-factory-guy';
 
 const modelType = 'user';
 
@@ -20,7 +24,7 @@ module(`Unit | Model | ${modelType}`, function(hooks) {
   });
 
   test('sample async unit test with async/await', async function(assert) {
-    Ember.run(async () => {
+    run(async () => {
       let mock = mockFindRecord('user');
       let userId = mock.get('id');
       let user = await FactoryGuy.store.findRecord('user', userId);
@@ -30,7 +34,7 @@ module(`Unit | Model | ${modelType}`, function(hooks) {
 
   test('sample async unit test with assert.async()', function(assert) {
     let done = assert.async();
-    Ember.run(() => {
+    run(() => {
       let mock = mockFindRecord('user');
       let userId = mock.get('id');
       FactoryGuy.store.findRecord('user', userId).then((user) => {

--- a/tests/unit/rest-adapter-test.js
+++ b/tests/unit/rest-adapter-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import FactoryGuy, {
@@ -36,7 +36,7 @@ module(serializer, function(hooks) {
 
   module(`#mockFindRecord custom`, function() {
     test("when returns json (plain) is used", function(assert) {
-      Ember.run(() => {
+      run(() => {
         let done      = assert.async(),
             json      = {profile: {id: 1, description: 'the desc'}},
             mock      = mockFindRecord('profile').returns({json}),
@@ -54,7 +54,7 @@ module(serializer, function(hooks) {
   module(`#mockCreate custom`, function() {
 
     test("match belongsTo with custom payloadKeyFromModelName function", function(assert) {
-      Ember.run(() => {
+      run(() => {
         let done = assert.async();
 
         let entryType = make('entry-type');
@@ -69,7 +69,7 @@ module(serializer, function(hooks) {
     });
 
     test("match hasMany with custom payloadKeyFromModelName function", function(assert) {
-      Ember.run(() => {
+      run(() => {
         let done = assert.async();
 
         let entry = make('entry');

--- a/tests/unit/shared-adapter-behaviour.js
+++ b/tests/unit/shared-adapter-behaviour.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import { all } from 'rsvp';
+import { A } from '@ember/array';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { isEquivalent } from 'ember-data-factory-guy/utils/helper-functions';
@@ -13,7 +14,6 @@ import $ from 'jquery';
 import Profile from 'dummy/models/profile';
 import SuperHero from 'dummy/models/super-hero';
 
-const A = Ember.A;
 let SharedBehavior = {};
 
 //////// mockFindRecord common /////////
@@ -755,7 +755,7 @@ SharedBehavior.mockQueryTests = function() {
 
     assert.equal(FactoryGuy.store.peekAll('user').get('content.length'), 2, 'start out with 2 instances');
 
-    let users = await Ember.run(async () => FactoryGuy.store.query('user', {name: 'Bob'}));
+    let users = await run(async () => FactoryGuy.store.query('user', {name: 'Bob'}));
     assert.equal(users.get('length'), 2);
     assert.equal(users.get('firstObject.name'), 'User1');
     assert.equal(users.get('firstObject.hats.length'), 2);
@@ -1138,7 +1138,7 @@ SharedBehavior.mockCreateTests = function() {
         return FactoryGuy.store.createRecord('profile', {description: 'whatever'});
       });
 
-      await Ember.RSVP.all(profiles.map(profile => profile.save()));
+      await all(profiles.map(profile => profile.save()));
 
       let ids = A(profiles).mapBy('id');
       let descriptions = A(profiles).mapBy('description');

--- a/tests/unit/shared-factory-guy-behaviour.js
+++ b/tests/unit/shared-factory-guy-behaviour.js
@@ -1,6 +1,11 @@
+import { run } from '@ember/runloop';
 import { test } from 'ember-qunit';
-import Ember from 'ember';
-import FactoryGuy, { buildList, make, makeList, makeNew } from 'ember-data-factory-guy';
+import FactoryGuy, {
+  buildList,
+  make,
+  makeList,
+  makeNew
+} from 'ember-data-factory-guy';
 
 import User from 'dummy/models/user';
 import BigHat from 'dummy/models/big-hat';
@@ -95,7 +100,7 @@ SharedBehavior.makeTests = function() {
 
 
   test("when hasMany ( asnyc ) associations assigned, belongTo parent is assigned", function(assert) {
-    Ember.run(function() {
+    run(function() {
       let done = assert.async();
 
       let user = make('user');
@@ -177,7 +182,7 @@ SharedBehavior.makeTests = function() {
 
 
   test("when hasMany ( async ) relationship is assigned, model relationship is synced on both sides", function(assert) {
-    Ember.run(function() {
+    run(function() {
       let done = assert.async();
 
       let property = make('property');
@@ -193,7 +198,7 @@ SharedBehavior.makeTests = function() {
 
 
   test("when belongsTo ( async ) parent is assigned, parent adds to hasMany records", function(assert) {
-    Ember.run(function() {
+    run(function() {
       let done = assert.async();
 
       let company = make('company');
@@ -309,14 +314,14 @@ SharedBehavior.makeTests = function() {
 
 
   test("using afterMake with transient attributes in definition", function(assert) {
-    Ember.run(function() {
+    run(function() {
       let property = FactoryGuy.make('property');
       assert.ok(property.get('name') === 'Silly property(FOR SALE)');
     });
   });
 
   test("using afterMake with transient attributes in options", function(assert) {
-    Ember.run(function() {
+    run(function() {
       let property = FactoryGuy.make('property', {for_sale: false});
       assert.ok(property.get('name') === 'Silly property');
     });


### PR DESCRIPTION
While exploring a solution for #365 I realized that some parts of the code still used `Ember` as a monolithic object. Therefore I applied `ember-modules-codemod` and updated the documentation where necessary. I also replaced the single use of `$.extend` with `assign` following the new syntax.