### PR TITLE
mockDelete should also add model to fake snapshot

### DIFF
--- a/addon/mocks/exposed-request-functions.js
+++ b/addon/mocks/exposed-request-functions.js
@@ -371,20 +371,19 @@ export function mockUpdate(...args) {
  @param {String} id optional id of record to delete
  */
 export function mockDelete(...args) {
-  let modelName, id;
+  let model, modelName, id;
 
   if (args[0] instanceof Model) {
-    let record = args[0];
-    modelName = record.constructor.modelName;
-    id = record.id;
-  } else if (typeof args[0] === "string" && typeof parseInt(args[1]) === "number") {
-    modelName = args[0];
-    id = args[1];
+    model = args[0];
+    id = model.id;
+    modelName = model.constructor.modelName;
+  } else if (typeof args[0] === "string") {
+    [modelName, id] = args
   }
 
   assert(`[ember-data-factory-guy] mockDelete requires at least a model type name`, modelName);
 
-  return new MockDeleteRequest(modelName, id);
+  return new MockDeleteRequest(modelName, {id, model});
 }
 
 /**

--- a/addon/mocks/mock-delete-request.js
+++ b/addon/mocks/mock-delete-request.js
@@ -1,16 +1,34 @@
+import FactoryGuy from '../factory-guy';
 import MockStoreRequest from './mock-store-request';
 import MaybeIdUrlMatch from './maybe-id-url-match';
 
 export default class MockDeleteRequest extends MaybeIdUrlMatch(MockStoreRequest) {
 
-  constructor(modelName, id) {
+  constructor(modelName, {id, model} = {}) {
     super(modelName, 'deleteRecord');
     this.id = id;
+    this.model = model;
     this.setupHandler();
   }
 
   getType() {
     return "DELETE";
+  }
+
+  /**
+   * Create fake snaphot with adapterOptions and record.
+   *
+   * Override the parent to find the model in the store if there is
+   * an id available
+   *
+   * @returns {{adapterOptions: (*|Object), record: (*|DS.Model)}}
+   */
+  makeFakeSnapshot() {
+    let snapshot = super.makeFakeSnapshot();
+    if (this.id && !this.model) {
+      snapshot.record = FactoryGuy.store.peekRecord(this.modelName, this.id);
+    }
+    return snapshot;
   }
 
 }

--- a/tests/unit/mocks/mock-delete-test.js
+++ b/tests/unit/mocks/mock-delete-test.js
@@ -60,4 +60,22 @@ module('MockDelete', function(hooks) {
     assert.equal(mock1.getUrl(), '/deleteMyZombie/2');
     adapter.urlForDeleteRecord.restore();
   });
+
+  test("#makeFakeSnapshot", function(assert) {
+    let user = make('user');
+
+    let tests = [
+      [[user], user, 'has record when model in arguments'],
+      [['user', user.id], user, 'has record when modelName, id in arguments'],
+      [['user'], undefined, 'does not have record when only modelName in arguments']
+    ];
+
+    for (let test of tests) {
+      let [args, expectedRecord, message] = test;
+      let mock     = mockDelete(...args),
+          snapshot = mock.makeFakeSnapshot(),
+          {record} = snapshot;
+      assert.deepEqual(record, expectedRecord, message);
+    }
+  });
 });


### PR DESCRIPTION
In regards to https://github.com/danielspaniel/ember-data-factory-guy/issues/374, we found a simpler workaround for the time being to have mockDelete support passing the model as record in the snapshot (since DS.Snapshot also passes this value), which we can utilize instead of `snapshot.attr` in our case. This was simpler than trying to mimic all functionality of DS.Snapshot (which is in -private namespace). 

This is what `mockUpdate` does as well and since `mockDelete` is generally dealing with a persisted record in the same way as `mockUpdate` they should behave the same in regards to generating a fake snapshot.

I simply copied over the `makeFakeSnapshot` method from `mock-update-request.js`. I don't know if there is a better way. I thought about a mixin like `AttributeMatcher` or `MaybeIdUrlMatch` but that would mean inheriting from multiple classes (which is not a pattern in the repo). The other options I thought of was adding a util method to house the logic, but this didn't feel like a util method.