### PR TITLE
Fix mock#withSomeParams issue

### DIFF
--- a/addon/mocks/mock-any-request.js
+++ b/addon/mocks/mock-any-request.js
@@ -1,6 +1,6 @@
 import MockRequest from './mock-request';
 import {
-  isEmptyObject, isEquivalent, paramsFromRequestBody, toGetParams, toParams
+  isEmptyObject, isEquivalent, isPartOf, paramsFromRequestBody, toGetParams, toParams
 } from "../utils/helper-functions";
 
 export default class MockAnyRequest extends MockRequest {
@@ -34,17 +34,28 @@ export default class MockAnyRequest extends MockRequest {
   }
 
   paramsMatch(request) {
-    if (!isEmptyObject(this.queryParams)) {
-      if (this.type === 'GET') {
-        return isEquivalent(request.queryParams, toGetParams(this.queryParams));
-      }
-      if (/POST|PUT|PATCH/.test(this.type)) {
-        const requestBody   = request.requestBody,
-              requestParams = paramsFromRequestBody(requestBody);
-        return isEquivalent(requestParams, toParams(this.queryParams));
-      }
+    if (!isEmptyObject(this.someQueryParams)) {
+      return this._tryMatchParams(request, this.someQueryParams, isPartOf);
     }
+
+    if (!isEmptyObject(this.queryParams)) {
+      return this._tryMatchParams(request, this.queryParams, isEquivalent);
+    }
+
     return true;
+  }
+
+  _tryMatchParams(request, handlerParams, comparisonFunction) {
+    if (this.type === 'GET') {
+      return comparisonFunction(request.queryParams, toGetParams(handlerParams));
+    }
+    if (/POST|PUT|PATCH/.test(this.type)) {
+      const requestBody = request.requestBody,
+        requestParams = paramsFromRequestBody(requestBody);
+      return comparisonFunction(requestParams, toParams(handlerParams));
+    }
+
+    return false;
   }
 
 }

--- a/tests/unit/mocks/mock-any-test.js
+++ b/tests/unit/mocks/mock-any-test.js
@@ -162,4 +162,38 @@ module('MockAny', function(hooks) {
     await $.ajax({type, url});
     assert.equal(theMock.timesCalled, 1, 'mock#timesCalled is called once');
   });
+
+  test("#withParams", async function(assert) {
+    const type       = 'POST',
+          url        = '/api/post/some-stuff',
+          dataFoo = { foo: 'foo' },
+          dataBar = { bar: 'bar' };
+
+    let fooMock = mock({url: '/api/post/some-stuff', type}).withParams(dataFoo);
+    let barMock = mock({url: '/api/post/some-stuff', type}).withParams(dataBar);
+    assert.equal(fooMock.timesCalled, 0, 'fooMock#timesCalled is initially 0');
+    assert.equal(barMock.timesCalled, 0, 'barMock#timesCalled is initially 0');
+
+    await $.ajax({type, url, data: dataFoo});
+    await $.ajax({type, url, data: dataBar});
+    assert.equal(fooMock.timesCalled, 1, 'fooMock#timesCalled is called once');
+    assert.equal(barMock.timesCalled, 1, 'barMock#timesCalled is called once');
+  });
+
+  test("#withSomeParams", async function(assert) {
+    const type       = 'POST',
+          url        = '/api/post/some-stuff',
+          dataFoo = { foo: 'foo' },
+          dataBar = { bar: 'bar' };
+
+    let fooMock = mock({url: '/api/post/some-stuff', type}).withSomeParams(dataFoo);
+    let barMock = mock({url: '/api/post/some-stuff', type}).withSomeParams(dataBar);
+    assert.equal(fooMock.timesCalled, 0, 'fooMock#timesCalled is initially 0');
+    assert.equal(barMock.timesCalled, 0, 'barMock#timesCalled is initially 0');
+
+    await $.ajax({type, url, data: dataFoo});
+    await $.ajax({type, url, data: dataBar});
+    assert.equal(fooMock.timesCalled, 1, 'fooMock#timesCalled is called once');
+    assert.equal(barMock.timesCalled, 1, 'barMock#timesCalled is called once');
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/danielspaniel/ember-data-factory-guy/issues/381

Allows you to use `withSomeParams` with `mock`