### PR TITLE
Fix relationship key transformation

### DIFF
--- a/addon/converter/fixture-converter.js
+++ b/addon/converter/fixture-converter.js
@@ -99,8 +99,8 @@ export default class FixtureConverter {
   }
 
   transformRelationshipKey(relationship) {
-    let {parentType} = relationship,
-        type         = parentType && parentType.modelName || relationship.type,
+    let {parentModelName, parentType} = relationship,
+        type         = parentModelName || parentType && parentType.modelName || relationship.type,
         transformFn  = this.getTransformKeyFunction(type, 'Relationship');
     return transformFn(relationship.key, relationship.kind);
   }

--- a/tests/dummy/app/models/dog.js
+++ b/tests/dummy/app/models/dog.js
@@ -1,7 +1,9 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
+import { belongsTo } from 'ember-data/relationships';
 
 export default Model.extend({
+  owner: belongsTo('person'),
   dogNumber: attr('string'),
   sound: attr('string'),
   tag: attr() // hash

--- a/tests/dummy/app/tests/factories/dog.js
+++ b/tests/dummy/app/tests/factories/dog.js
@@ -13,6 +13,7 @@ FactoryGuy.define('dog', {
   },
 
   traits: {
-    cowDog: { sound: mooSound }
+    cowDog: { sound: mooSound },
+    withOwner: { owner: FactoryGuy.belongsTo('employee') }
   }
 });

--- a/tests/helpers/utility-methods.js
+++ b/tests/helpers/utility-methods.js
@@ -57,7 +57,10 @@ const serializerOptions = {
     }
   },
   dog: {
-    primaryKey: 'dogNumber'
+    primaryKey: 'dogNumber',
+    attrs: {
+      owner: { key: 'humanId' }
+    }
   },
   cat: {
     primaryKey: 'catId',

--- a/tests/unit/active-model-adapter-test.js
+++ b/tests/unit/active-model-adapter-test.js
@@ -51,6 +51,12 @@ module(serializer, function(hooks) {
 
   module('FactoryGuy#build custom', function() {
 
+    test("uses the correct key when overridden in the serializer", async function(assert) {
+      let buildJson = build('dog', 'withOwner');
+      assert.equal(buildJson.get('owner_id'), undefined);
+      assert.equal(buildJson.get('humanId'), 1);
+    });
+
     test("embeds hasMany record when serializer attrs => embedded: always ", function(assert) {
 
       let buildJson = build('comic-book', 'with_included_villains');

--- a/tests/unit/active-model-adapter-test.js
+++ b/tests/unit/active-model-adapter-test.js
@@ -60,7 +60,7 @@ module(serializer, function(hooks) {
         comic_book: {
           id: 1,
           name: 'Comic Times #1',
-          included_villain_ids: [
+          included_villains: [
             {id: 1, type: 'Villain', name: 'BadGuy#1'},
             {id: 2, type: 'Villain', name: 'BadGuy#2'},
           ]


### PR DESCRIPTION
This fixes https://github.com/danielspaniel/ember-data-factory-guy/issues/393
Not sure if I need to keep the `parentType` property there.

Could also do with adding another test for a serializer which includes a custom relationship key.