### PR TITLE
Fix .withParams for array parameters

### DIFF
--- a/addon/mocks/mock-any-request.js
+++ b/addon/mocks/mock-any-request.js
@@ -1,6 +1,6 @@
 import MockRequest from './mock-request';
 import {
-  isEmptyObject, isEquivalent, isPartOf, paramsFromRequestBody, toGetParams, toParams
+  isEmptyObject, isEquivalent, isPartOf, paramsFromRequestBody, param, toParams
 } from "../utils/helper-functions";
 
 export default class MockAnyRequest extends MockRequest {
@@ -47,7 +47,7 @@ export default class MockAnyRequest extends MockRequest {
 
   _tryMatchParams(request, handlerParams, comparisonFunction) {
     if (this.type === 'GET') {
-      return comparisonFunction(toGetParams(request.queryParams), toGetParams(handlerParams));
+      return comparisonFunction(param(request.queryParams), param(handlerParams));
     }
 
     if (/POST|PUT|PATCH/.test(this.type)) {

--- a/addon/mocks/mock-any-request.js
+++ b/addon/mocks/mock-any-request.js
@@ -53,7 +53,7 @@ export default class MockAnyRequest extends MockRequest {
     if (/POST|PUT|PATCH/.test(this.type)) {
       const requestBody   = request.requestBody,
             requestParams = paramsFromRequestBody(requestBody);
-      return comparisonFunction(requestParams, toParams(handlerParams));
+      return comparisonFunction(toParams(requestParams), toParams(handlerParams));
     }
 
     return false;

--- a/addon/utils/helper-functions.js
+++ b/addon/utils/helper-functions.js
@@ -25,38 +25,6 @@ export function paramsFromRequestBody(body) {
   return body;
 }
 
-/**
- *
- * @param obj
- */
-export function toGetParams(obj) {
-  let convertedParams = Object.assign({}, obj);
-  Object.keys(convertedParams).forEach(key => {
-    let value = convertedParams[key];
-    if (typeOf(value) === 'array') {
-      value.forEach((v,i) => {
-        convertedParams[`${key}[${i}]`] = String(v)
-      });
-      delete convertedParams[key];
-    }
-    if (typeof value === 'number') {
-      convertedParams[key] = String(value);
-    }
-    if (typeof value === 'boolean') {
-      convertedParams[key] = String(value);
-    }
-    if (typeOf(value) === 'object') {
-      Object.keys(value).forEach((vKey) => {
-        let pKey = `${key}[${vKey}]`,
-            vValue = value[vKey];
-        convertedParams[pKey] = String(vValue);
-      });
-      delete convertedParams[key];
-    }
-  });
-  return convertedParams;
-}
-
 export function toParams(obj) {
   return parseParms(decodeURIComponent(param(obj)));
 }

--- a/tests/helpers/utility-methods.js
+++ b/tests/helpers/utility-methods.js
@@ -9,14 +9,13 @@ import { ActiveModelSerializer } from 'active-model-adapter';
 import AdapterFetch from 'ember-fetch/mixins/adapter-fetch';
 
 export function fetchJSON({url, params, method = 'GET'} = {}) {
-  if (method === "GET") {
-    return fetch([url, param(params)].join('?'), {method}).then(r => r.json());
+  let body = '';
+  if (method === 'GET') {
+    url = [url, param(params)].join('?');
   } else {
-    const body = JSON.stringify(params)
-    return fetch(url, {body, method}).then(r => {
-      return r._bodyText ? r.json() : null;
-    });
+    body = JSON.stringify(params);
   }
+  return fetch(url, {body, method}).then(r => r._bodyText ? r.json() : null);
 }
 
 //// custom adapter options for the various models

--- a/tests/unit/mocks/mock-any-test.js
+++ b/tests/unit/mocks/mock-any-test.js
@@ -202,10 +202,10 @@ module('MockAny', function(hooks) {
   });
 
   function testWithParamsForMethod(method) {
-    test(`#withParams works with arrays for ${method} requests`, async function(assert) {
+    test(`#withParams works with complex parameters for ${method} requests`, async function(assert) {
       const url     = '/api/post/some-stuff',
-            dataFoo = {foo: 'foo', labels: ['a', 'b', 'c']},
-            dataBar = {bar: 'bar', labels: [1, 2, 3]};
+            dataFoo = {foo: 'foo', array: ['a', { b: 123 }, 'c'], obj: { a: 321 } },
+            dataBar = {bar: 'bar', array: [1, { x: 2 }, 3], obj: { x: 321 } };
 
       let fooMock = mock({url, type: method}).withParams(dataFoo);
       let barMock = mock({url, type: method}).withParams(dataBar);
@@ -213,8 +213,10 @@ module('MockAny', function(hooks) {
       assert.equal(barMock.timesCalled, 0, 'barMock#timesCalled is initially 0');
 
       await fetchJSON({url, params: dataFoo, method});
-      await fetchJSON({url, params: dataBar, method});
+      assert.equal(fooMock.timesCalled, 1, 'fooMock#timesCalled is called once');
+      assert.equal(barMock.timesCalled, 0, 'barMock#timesCalled is called once');
 
+      await fetchJSON({url, params: dataBar, method});
       assert.equal(fooMock.timesCalled, 1, 'fooMock#timesCalled is called once');
       assert.equal(barMock.timesCalled, 1, 'barMock#timesCalled is called once');
     });

--- a/tests/unit/mocks/mock-any-test.js
+++ b/tests/unit/mocks/mock-any-test.js
@@ -200,4 +200,25 @@ module('MockAny', function(hooks) {
     assert.equal(fooMock.timesCalled, 1, 'fooMock#timesCalled is called once');
     assert.equal(barMock.timesCalled, 1, 'barMock#timesCalled is called once');
   });
+
+  function testWithParamsForMethod(method) {
+    test(`#withParams works with arrays for ${method} requests`, async function(assert) {
+      const url     = '/api/post/some-stuff',
+            dataFoo = {foo: 'foo', labels: ['a', 'b', 'c']},
+            dataBar = {bar: 'bar', labels: [1, 2, 3]};
+
+      let fooMock = mock({url, type: method}).withParams(dataFoo);
+      let barMock = mock({url, type: method}).withParams(dataBar);
+      assert.equal(fooMock.timesCalled, 0, 'fooMock#timesCalled is initially 0');
+      assert.equal(barMock.timesCalled, 0, 'barMock#timesCalled is initially 0');
+
+      await fetchJSON({url, params: dataFoo, method});
+      await fetchJSON({url, params: dataBar, method});
+
+      assert.equal(fooMock.timesCalled, 1, 'fooMock#timesCalled is called once');
+      assert.equal(barMock.timesCalled, 1, 'barMock#timesCalled is called once');
+    });
+  }
+
+  ['GET', 'POST', 'PATCH', 'PUT'].forEach(testWithParamsForMethod);
 });

--- a/tests/unit/mocks/mock-request-test.js
+++ b/tests/unit/mocks/mock-request-test.js
@@ -13,6 +13,18 @@ module('MockRequest', function(hooks) {
   setupTest(hooks);
   inlineSetup(hooks, serializerType);
 
+  module('#withParams', function() {
+    test('works with arrays', async function(assert) {
+      const mockWithoutArray = mockQueryRecord('company', { foo: 123 }).returns({json: build('company')});
+      const mockWithArray = mockQueryRecord('company', { array: [1, 2, 3] }).returns({json: build('company')});
+      assert.equal(mockWithoutArray.timesCalled, 0);
+      assert.equal(mockWithArray.timesCalled, 0);
+      await FactoryGuy.store.queryRecord('company', { array: [1, 2, 3] });
+      assert.equal(mockWithoutArray.timesCalled, 0);
+      assert.equal(mockWithArray.timesCalled, 1);
+    });
+  });
+
   module('#fails', function() {
     test("status must be 3XX, 4XX or 5XX", function(assert) {
       const mock = new MockRequest('user');

--- a/tests/unit/mocks/mock-request-test.js
+++ b/tests/unit/mocks/mock-request-test.js
@@ -13,18 +13,6 @@ module('MockRequest', function(hooks) {
   setupTest(hooks);
   inlineSetup(hooks, serializerType);
 
-  module('#withParams', function() {
-    test('works with arrays', async function(assert) {
-      const mockWithoutArray = mockQueryRecord('company', { foo: 123 }).returns({json: build('company')});
-      const mockWithArray = mockQueryRecord('company', { array: [1, 2, 3] }).returns({json: build('company')});
-      assert.equal(mockWithoutArray.timesCalled, 0);
-      assert.equal(mockWithArray.timesCalled, 0);
-      await FactoryGuy.store.queryRecord('company', { array: [1, 2, 3] });
-      assert.equal(mockWithoutArray.timesCalled, 0);
-      assert.equal(mockWithArray.timesCalled, 1);
-    });
-  });
-
   module('#fails', function() {
     test("status must be 3XX, 4XX or 5XX", function(assert) {
       const mock = new MockRequest('user');


### PR DESCRIPTION
A `MockAnyRequest` currently won't correctly match requests when the `.withParams` method is used with array parameters.