### PR TITLE
Fix snapshot record for Get requests

### DIFF
--- a/addon/mocks/mock-delete-request.js
+++ b/addon/mocks/mock-delete-request.js
@@ -14,21 +14,4 @@ export default class MockDeleteRequest extends MaybeIdUrlMatch(MockStoreRequest)
   getType() {
     return "DELETE";
   }
-
-  /**
-   * Create fake snaphot with adapterOptions and record.
-   *
-   * Override the parent to find the model in the store if there is
-   * an id available
-   *
-   * @returns {{adapterOptions: (*|Object), record: (*|DS.Model)}}
-   */
-  makeFakeSnapshot() {
-    let snapshot = super.makeFakeSnapshot();
-    if (this.id && !this.model) {
-      snapshot.record = FactoryGuy.store.peekRecord(this.modelName, this.id);
-    }
-    return snapshot;
-  }
-
 }

--- a/addon/mocks/mock-delete-request.js
+++ b/addon/mocks/mock-delete-request.js
@@ -1,4 +1,3 @@
-import FactoryGuy from '../factory-guy';
 import MockStoreRequest from './mock-store-request';
 import MaybeIdUrlMatch from './maybe-id-url-match';
 

--- a/addon/mocks/mock-get-request.js
+++ b/addon/mocks/mock-get-request.js
@@ -130,7 +130,6 @@ class MockGetRequest extends MockStoreRequest {
     this.responseJson = json;
     this.setupHandler();
   }
-
 }
 
 export default MockGetRequest;

--- a/addon/mocks/mock-store-request.js
+++ b/addon/mocks/mock-store-request.js
@@ -45,7 +45,12 @@ export default class extends MockRequest {
    * @returns {{adapterOptions: (*|Object), record: (*|DS.Model)}}
    */
   makeFakeSnapshot() {
-    return {adapterOptions: this.adapterOptions, record: this.model};
-  }
+    let record = this.model;
 
+    if (!record && this.get('id')) {
+      record = FactoryGuy.store.peekRecord(this.modelName, this.get('id'));
+    }
+
+    return {adapterOptions: this.adapterOptions, record};
+  }
 }

--- a/addon/mocks/mock-update-request.js
+++ b/addon/mocks/mock-update-request.js
@@ -21,22 +21,6 @@ export default class MockUpdateRequest extends MaybeIdUrlMatch(AttributeMatcher(
   }
 
   /**
-   * Create fake snaphot with adapterOptions and record.
-   *
-   * Override the parent to find the model in the store if there is
-   * an id available
-   *
-   * @returns {{adapterOptions: (*|Object), record: (*|DS.Model)}}
-   */
-  makeFakeSnapshot() {
-    let snapshot = super.makeFakeSnapshot();
-    if (this.id && !this.model) {
-      snapshot.record = FactoryGuy.store.peekRecord(this.modelName, this.id);
-    }
-    return snapshot;
-  }
-
-  /**
    This returns only accepts attrs key
 
    These attrs are those attributes or relationships that

--- a/tests/unit/mocks/mock-find-record-test.js
+++ b/tests/unit/mocks/mock-find-record-test.js
@@ -85,10 +85,12 @@ module('MockFindRecord', function(hooks) {
           adapter        = FactoryGuy.store.adapterFor('user'),
           findRecordStub = sinon.stub(adapter, 'urlForFindRecord');
 
+      const user = FactoryGuy.store.peekRecord('user', 1);
+
       mock.getUrl();
 
       assert.ok(findRecordStub.calledOnce);
-      assert.ok(findRecordStub.calledWith(1, 'user', {adapterOptions: options, record: undefined}), 'adapterOptions passed to urlForFindRecord');
+      assert.ok(findRecordStub.calledWith(1, 'user', {adapterOptions: options, record: user}), 'adapterOptions passed to urlForFindRecord');
 
       adapter.urlForFindRecord.restore();
     });


### PR DESCRIPTION
Related issue: https://github.com/danielspaniel/ember-data-factory-guy/issues/409
Problem:

While developing one of the tests in my app it turned out that when creating mocked find operation from already mocked model, like:

```
const user = make('user');
mockFindRecord(user);
```

the Snapshot object never had the `record` set to this model.