### PR TITLE
fix error when adapter modifies queryParams

### DIFF
--- a/addon/factory-guy.js
+++ b/addon/factory-guy.js
@@ -525,7 +525,11 @@ class FactoryGuy {
    */
   buildURL(modelName, id = null, snapshot, requestType, queryParams) {
     const adapter = this.store.adapterFor(modelName);
-    return adapter.buildURL(modelName, id, snapshot, requestType, queryParams);
+    const clonedQueryParams = assign({}, queryParams);
+    // some adapters can modify the query params so use a copy
+    // so as not to modify the internal stored params
+    // which are important later
+    return adapter.buildURL(modelName, id, snapshot, requestType, clonedQueryParams);
   }
 
   /**


### PR DESCRIPTION
Clones the query params before handing off to the adapter in case the adapter modifies it