### PR TITLE
Set `isDevelopingAddOn = false`

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-data-factory-guy',
-  isDevelopingAddon: function() { return true; },
+  isDevelopingAddon: function() { return false; },
   // borrowed from ember-cli-pretender
   _findPretenderPaths: function() {
     if (!this._pretenderPath) {


### PR DESCRIPTION
Setting this to true causes the Ember process to watch the addon directories for changes and live reload when something changes ([documentation](https://ember-cli.com/api/classes/Addon.html#method_isDevelopingAddon)). We generally don't want to live reload when something in `node_modules` changes unless we are actively working on it and with a polling watcher this can be CPU intensive. Based on [the commit where it was introduced](https://github.com/danielspaniel/ember-data-factory-guy/commit/7b57d0daa600ffa783bfb5859e9d74a1e0a90375), which appears to be unrelated, I think introducing this may have been unintentional.