### PR TITLE
Change ownership to adopted-ember-addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1222 +1,1222 @@
 # Change Log
 
-## [Unreleased](https://github.com/danielspaniel/ember-data-factory-guy/tree/HEAD)
+## [Unreleased](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/HEAD)
 
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.12.2...HEAD)
-
-**Closed issues:**
-
-- SyntaxError: ember-data-factory-guy/scenario.js: Unexpected token \(6:21\) [\#278](https://github.com/danielspaniel/ember-data-factory-guy/issues/278)
-
-## [v2.12.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.12.2) (2017-03-23)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.12.1...v2.12.2)
-
-## [v2.12.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.12.1) (2017-03-22)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.12.0...v2.12.1)
-
-**Merged pull requests:**
-
-- Silence JavaScript preprocessor deprecation warning on Ember 2.12 [\#277](https://github.com/danielspaniel/ember-data-factory-guy/pull/277) ([vluoto](https://github.com/vluoto))
-
-## [v2.12.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.12.0) (2017-03-18)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.11.7...v2.12.0)
-
-## [v2.11.7](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.11.7) (2017-03-14)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.11.6...v2.11.7)
-
-**Merged pull requests:**
-
-- fix build if ember-data-factory-guy used for tests inside addon [\#276](https://github.com/danielspaniel/ember-data-factory-guy/pull/276) ([canufeel](https://github.com/canufeel))
-
-## [v2.11.6](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.11.6) (2017-02-16)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.11.5...v2.11.6)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.12.2...HEAD)
 
 **Closed issues:**
 
-- mockFindAll fails in route test on Ember 2.11 [\#273](https://github.com/danielspaniel/ember-data-factory-guy/issues/273)
+- SyntaxError: ember-data-factory-guy/scenario.js: Unexpected token \(6:21\) [\#278](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/278)
+
+## [v2.12.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.12.2) (2017-03-23)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.12.1...v2.12.2)
+
+## [v2.12.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.12.1) (2017-03-22)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.12.0...v2.12.1)
 
 **Merged pull requests:**
 
-- Add 'addon' guard to treeFor method [\#275](https://github.com/danielspaniel/ember-data-factory-guy/pull/275) ([tschoartschi](https://github.com/tschoartschi))
-- Some tweaks to the README [\#274](https://github.com/danielspaniel/ember-data-factory-guy/pull/274) ([lorcan](https://github.com/lorcan))
+- Silence JavaScript preprocessor deprecation warning on Ember 2.12 [\#277](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/277) ([vluoto](https://github.com/vluoto))
 
-## [v2.11.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.11.5) (2017-02-02)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.11.4...v2.11.5)
+## [v2.12.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.12.0) (2017-03-18)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.11.7...v2.12.0)
 
-## [v2.11.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.11.4) (2017-02-01)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.11.3...v2.11.4)
+## [v2.11.7](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.11.7) (2017-03-14)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.11.6...v2.11.7)
+
+**Merged pull requests:**
+
+- fix build if ember-data-factory-guy used for tests inside addon [\#276](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/276) ([canufeel](https://github.com/canufeel))
+
+## [v2.11.6](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.11.6) (2017-02-16)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.11.5...v2.11.6)
 
 **Closed issues:**
 
-- .add\({ meta: not working [\#272](https://github.com/danielspaniel/ember-data-factory-guy/issues/272)
+- mockFindAll fails in route test on Ember 2.11 [\#273](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/273)
 
 **Merged pull requests:**
 
-- Update package.json to be the correct release number [\#271](https://github.com/danielspaniel/ember-data-factory-guy/pull/271) ([patocallaghan](https://github.com/patocallaghan))
+- Add 'addon' guard to treeFor method [\#275](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/275) ([tschoartschi](https://github.com/tschoartschi))
+- Some tweaks to the README [\#274](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/274) ([lorcan](https://github.com/lorcan))
 
-## [v2.11.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.11.3) (2017-01-26)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.11.2...v2.11.3)
+## [v2.11.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.11.5) (2017-02-02)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.11.4...v2.11.5)
 
-## [v2.11.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.11.2) (2017-01-26)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.11.1...v2.11.2)
-
-## [v2.11.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.11.1) (2017-01-24)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.11.0...v2.11.1)
+## [v2.11.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.11.4) (2017-02-01)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.11.3...v2.11.4)
 
 **Closed issues:**
 
-- add ability to make models in the new state [\#269](https://github.com/danielspaniel/ember-data-factory-guy/issues/269)
-
-## [v2.11.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.11.0) (2017-01-23)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.10.1...v2.11.0)
-
-## [v2.10.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.10.1) (2017-01-21)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.10.0...v2.10.1)
+- .add\({ meta: not working [\#272](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/272)
 
 **Merged pull requests:**
 
-- Fix DjangoSerializer import [\#270](https://github.com/danielspaniel/ember-data-factory-guy/pull/270) ([erkarl](https://github.com/erkarl))
+- Update package.json to be the correct release number [\#271](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/271) ([patocallaghan](https://github.com/patocallaghan))
 
-## [v2.10.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.10.0) (2017-01-10)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.9.8...v2.10.0)
+## [v2.11.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.11.3) (2017-01-26)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.11.2...v2.11.3)
 
-**Merged pull requests:**
+## [v2.11.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.11.2) (2017-01-26)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.11.1...v2.11.2)
 
-- Use assert rather than warn for missing traits [\#266](https://github.com/danielspaniel/ember-data-factory-guy/pull/266) ([lorcan](https://github.com/lorcan))
-
-## [v2.9.8](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.9.8) (2016-12-13)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.9.7...v2.9.8)
-
-**Merged pull requests:**
-
-- Misc. typo fixes [\#265](https://github.com/danielspaniel/ember-data-factory-guy/pull/265) ([lorcan](https://github.com/lorcan))
-- Allow mockCreate/mockUpdate to receive a matching function [\#263](https://github.com/danielspaniel/ember-data-factory-guy/pull/263) ([lorcan](https://github.com/lorcan))
-
-## [v2.9.7](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.9.7) (2016-11-30)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.9.5...v2.9.7)
-
-## [v2.9.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.9.5) (2016-11-29)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.9.4...v2.9.5)
+## [v2.11.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.11.1) (2017-01-24)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.11.0...v2.11.1)
 
 **Closed issues:**
 
-- `Cannot read property '\_super' of undefined` with Ember 2.10.0 [\#260](https://github.com/danielspaniel/ember-data-factory-guy/issues/260)
+- add ability to make models in the new state [\#269](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/269)
 
-## [v2.9.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.9.4) (2016-11-29)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.9.3...v2.9.4)
+## [v2.11.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.11.0) (2017-01-23)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.10.1...v2.11.0)
+
+## [v2.10.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.10.1) (2017-01-21)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.10.0...v2.10.1)
+
+**Merged pull requests:**
+
+- Fix DjangoSerializer import [\#270](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/270) ([erkarl](https://github.com/erkarl))
+
+## [v2.10.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.10.0) (2017-01-10)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.9.8...v2.10.0)
+
+**Merged pull requests:**
+
+- Use assert rather than warn for missing traits [\#266](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/266) ([lorcan](https://github.com/lorcan))
+
+## [v2.9.8](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.9.8) (2016-12-13)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.9.7...v2.9.8)
+
+**Merged pull requests:**
+
+- Misc. typo fixes [\#265](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/265) ([lorcan](https://github.com/lorcan))
+- Allow mockCreate/mockUpdate to receive a matching function [\#263](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/263) ([lorcan](https://github.com/lorcan))
+
+## [v2.9.7](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.9.7) (2016-11-30)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.9.5...v2.9.7)
+
+## [v2.9.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.9.5) (2016-11-29)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.9.4...v2.9.5)
+
+**Closed issues:**
+
+- `Cannot read property '\_super' of undefined` with Ember 2.10.0 [\#260](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/260)
+
+## [v2.9.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.9.4) (2016-11-29)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.9.3...v2.9.4)
 
 **Implemented enhancements:**
 
-- allow for afterMake callbacks in named definitions [\#79](https://github.com/danielspaniel/ember-data-factory-guy/issues/79)
+- allow for afterMake callbacks in named definitions [\#79](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/79)
 
-## [v2.9.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.9.3) (2016-11-16)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.9.2...v2.9.3)
-
-**Implemented enhancements:**
-
-- implement the rest of the urlFor... methods ..  urlForFindRecord is only one currently supported [\#246](https://github.com/danielspaniel/ember-data-factory-guy/issues/246)
-
-**Merged pull requests:**
-
-- Fix typo for defining fragment factories [\#258](https://github.com/danielspaniel/ember-data-factory-guy/pull/258) ([supremebeing7](https://github.com/supremebeing7))
-- addIncludedArray\(\) replacing payload data with included [\#253](https://github.com/danielspaniel/ember-data-factory-guy/pull/253) ([cristinawithout](https://github.com/cristinawithout))
-
-## [v2.9.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.9.2) (2016-11-07)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.9.1...v2.9.2)
-
-## [v2.9.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.9.1) (2016-11-05)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.9.0...v2.9.1)
-
-**Closed issues:**
-
-- Using different adapter/serializer for different models may cause an issue if different from application adapter/serilizer [\#256](https://github.com/danielspaniel/ember-data-factory-guy/issues/256)
-
-## [v2.9.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.9.0) (2016-11-04)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.8.2...v2.9.0)
-
-## [v2.8.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.8.2) (2016-10-27)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.8.1...v2.8.2)
-
-**Closed issues:**
-
-- Add support for using factory-guy in other environments besides development and test [\#254](https://github.com/danielspaniel/ember-data-factory-guy/issues/254)
-
-**Merged pull requests:**
-
-- Add support for using factory-guy in other environments [\#255](https://github.com/danielspaniel/ember-data-factory-guy/pull/255) ([juwara0](https://github.com/juwara0))
-
-## [v2.8.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.8.1) (2016-10-20)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.8.0...v2.8.1)
-
-**Merged pull requests:**
-
-- Fix a link to mockFindRecord in the readme [\#252](https://github.com/danielspaniel/ember-data-factory-guy/pull/252) ([whatthewhat](https://github.com/whatthewhat))
-
-## [v2.8.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.8.0) (2016-09-26)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.10...v2.8.0)
-
-## [v2.7.10](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.10) (2016-09-20)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.9...v2.7.10)
-
-**Closed issues:**
-
-- Deprecation warnings on Ember 2.8 [\#250](https://github.com/danielspaniel/ember-data-factory-guy/issues/250)
-
-**Merged pull requests:**
-
-- Use Array.includes instead of deprecated contains if possible [\#251](https://github.com/danielspaniel/ember-data-factory-guy/pull/251) ([mdentremont](https://github.com/mdentremont))
-
-## [v2.7.9](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.9) (2016-09-13)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.8...v2.7.9)
-
-**Closed issues:**
-
-- mockFind with RESTAdaptor clobbers type attribute on model [\#248](https://github.com/danielspaniel/ember-data-factory-guy/issues/248)
-- Test Helpers in Factory break development build [\#247](https://github.com/danielspaniel/ember-data-factory-guy/issues/247)
-
-## [v2.7.8](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.8) (2016-09-11)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.7...v2.7.8)
-
-**Closed issues:**
-
-- Manually adding model fragment causing error [\#244](https://github.com/danielspaniel/ember-data-factory-guy/issues/244)
-
-## [v2.7.7](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.7) (2016-09-08)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.6...v2.7.7)
-
-**Closed issues:**
-
-- Having a property called "type" on your model causes `make` to fail [\#242](https://github.com/danielspaniel/ember-data-factory-guy/issues/242)
-- Mock URL matching not working with query params [\#239](https://github.com/danielspaniel/ember-data-factory-guy/issues/239)
-
-## [v2.7.6](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.6) (2016-09-06)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.5...v2.7.6)
-
-**Closed issues:**
-
-- Mocking a singularized endpoint [\#241](https://github.com/danielspaniel/ember-data-factory-guy/issues/241)
-- You can no longer create model fragments on their own using make or makeList [\#238](https://github.com/danielspaniel/ember-data-factory-guy/issues/238)
-- Field called type raises error [\#237](https://github.com/danielspaniel/ember-data-factory-guy/issues/237)
-- FactoryGuy.define devours the supplied config object [\#235](https://github.com/danielspaniel/ember-data-factory-guy/issues/235)
-- Build strategies for related data [\#234](https://github.com/danielspaniel/ember-data-factory-guy/issues/234)
-- Latest change in 2.7.4 breaks models that have an attribute `type` [\#233](https://github.com/danielspaniel/ember-data-factory-guy/issues/233)
-
-**Merged pull requests:**
-
-- Added test to check url matching of mockDelete and mockUpdate [\#240](https://github.com/danielspaniel/ember-data-factory-guy/pull/240) ([danielspaniel](https://github.com/danielspaniel))
-- es6 args destructuring removed from public api on mocks [\#236](https://github.com/danielspaniel/ember-data-factory-guy/pull/236) ([youroff](https://github.com/youroff))
-
-## [v2.7.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.5) (2016-08-25)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.4...v2.7.5)
-
-**Closed issues:**
-
-- Bizarre issue with make and makeList [\#232](https://github.com/danielspaniel/ember-data-factory-guy/issues/232)
-- Returning inherited models of various types [\#231](https://github.com/danielspaniel/ember-data-factory-guy/issues/231)
-- How to mock requests to custom endpoints in integration test [\#230](https://github.com/danielspaniel/ember-data-factory-guy/issues/230)
-- TypeError: uri.path is not a function [\#225](https://github.com/danielspaniel/ember-data-factory-guy/issues/225)
-
-## [v2.7.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.4) (2016-08-22)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.3...v2.7.4)
-
-**Closed issues:**
-
-- mockFindAll, mockQuery, etc weird behavior with fails [\#224](https://github.com/danielspaniel/ember-data-factory-guy/issues/224)
-- Strange behavior when using custom serializers [\#223](https://github.com/danielspaniel/ember-data-factory-guy/issues/223)
-- A typo in scenario.js [\#222](https://github.com/danielspaniel/ember-data-factory-guy/issues/222)
-
-**Merged pull requests:**
-
-- Update README to reflect mockTeardown\(\) usage in component tests [\#229](https://github.com/danielspaniel/ember-data-factory-guy/pull/229) ([oniofchaos](https://github.com/oniofchaos))
-- disable\(\), enable\(\), and destroy\(\) methods for mocks [\#228](https://github.com/danielspaniel/ember-data-factory-guy/pull/228) ([ryedeer](https://github.com/ryedeer))
-- withSomeParams modifier for mockGetRequest [\#227](https://github.com/danielspaniel/ember-data-factory-guy/pull/227) ([youroff](https://github.com/youroff))
-
-## [v2.7.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.3) (2016-08-01)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.2...v2.7.3)
-
-## [v2.7.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.2) (2016-07-26)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.1...v2.7.2)
-
-**Closed issues:**
-
-- Non-integer primary keys are forced to the model's `id` during make/build [\#220](https://github.com/danielspaniel/ember-data-factory-guy/issues/220)
-
-**Merged pull requests:**
-
-- mockFind does not return a failed response [\#221](https://github.com/danielspaniel/ember-data-factory-guy/pull/221) ([daibhin](https://github.com/daibhin))
-
-## [v2.7.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.1) (2016-07-13)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.0...v2.7.1)
-
-**Closed issues:**
-
-- \[FEATURE REQUEST\] Add support for serializer renamed fields \(ie: `attrs: { localKey: 'serverKey'}`\) [\#219](https://github.com/danielspaniel/ember-data-factory-guy/issues/219)
-
-## [v2.7.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.0) (2016-07-12)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.0-beta.11...v2.7.0)
-
-**Closed issues:**
-
-- Make throws a registry.resolve error [\#218](https://github.com/danielspaniel/ember-data-factory-guy/issues/218)
-
-## [v2.7.0-beta.11](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.0-beta.11) (2016-07-08)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.0-beta.10...v2.7.0-beta.11)
-
-**Closed issues:**
-
-- .match\(\) for mockUpdate\(\) [\#216](https://github.com/danielspaniel/ember-data-factory-guy/issues/216)
-
-## [v2.7.0-beta.10](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.0-beta.10) (2016-07-07)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.0-beta.9...v2.7.0-beta.10)
+## [v2.9.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.9.3) (2016-11-16)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.9.2...v2.9.3)
 
 **Implemented enhancements:**
 
-- Fix =\> DEPRECATION: `InvalidError` expects json-api formatted errors. [\#123](https://github.com/danielspaniel/ember-data-factory-guy/issues/123)
-
-**Closed issues:**
-
-- fails\(\)'s convertResponseErrors\(\) doesn't allow for using error 'meta' property or returning exact response passed [\#215](https://github.com/danielspaniel/ember-data-factory-guy/issues/215)
+- implement the rest of the urlFor... methods ..  urlForFindRecord is only one currently supported [\#246](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/246)
 
 **Merged pull requests:**
 
-- Tests for mockUpdate.match \#216 [\#217](https://github.com/danielspaniel/ember-data-factory-guy/pull/217) ([cristinawithout](https://github.com/cristinawithout))
+- Fix typo for defining fragment factories [\#258](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/258) ([supremebeing7](https://github.com/supremebeing7))
+- addIncludedArray\(\) replacing payload data with included [\#253](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/253) ([cristinawithout](https://github.com/cristinawithout))
 
-## [v2.7.0-beta.9](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.0-beta.9) (2016-07-04)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.0-beta.8...v2.7.0-beta.9)
+## [v2.9.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.9.2) (2016-11-07)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.9.1...v2.9.2)
+
+## [v2.9.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.9.1) (2016-11-05)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.9.0...v2.9.1)
 
 **Closed issues:**
 
-- match\(\) fails with JSONAPI for relationship when serializer's payloadKeyFromModelName\(\) doesn't pluralize [\#213](https://github.com/danielspaniel/ember-data-factory-guy/issues/213)
+- Using different adapter/serializer for different models may cause an issue if different from application adapter/serilizer [\#256](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/256)
 
-## [v2.7.0-beta.8](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.0-beta.8) (2016-06-30)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.0-beta.7...v2.7.0-beta.8)
+## [v2.9.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.9.0) (2016-11-04)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.8.2...v2.9.0)
+
+## [v2.8.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.8.2) (2016-10-27)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.8.1...v2.8.2)
+
+**Closed issues:**
+
+- Add support for using factory-guy in other environments besides development and test [\#254](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/254)
 
 **Merged pull requests:**
 
-- Issue 213 jsonapi payloadkey [\#214](https://github.com/danielspaniel/ember-data-factory-guy/pull/214) ([cristinawithout](https://github.com/cristinawithout))
+- Add support for using factory-guy in other environments [\#255](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/255) ([juwara0](https://github.com/juwara0))
 
-## [v2.7.0-beta.7](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.0-beta.7) (2016-06-28)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.0-beta.6...v2.7.0-beta.7)
+## [v2.8.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.8.1) (2016-10-20)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.8.0...v2.8.1)
 
-## [v2.7.0-beta.6](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.0-beta.6) (2016-06-27)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.0-beta.5...v2.7.0-beta.6)
+**Merged pull requests:**
 
-## [v2.7.0-beta.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.0-beta.5) (2016-06-23)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.0-beta.4...v2.7.0-beta.5)
+- Fix a link to mockFindRecord in the readme [\#252](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/252) ([whatthewhat](https://github.com/whatthewhat))
 
-## [v2.7.0-beta.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.0-beta.4) (2016-06-23)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.0-beta.3...v2.7.0-beta.4)
+## [v2.8.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.8.0) (2016-09-26)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.10...v2.8.0)
 
-## [v2.7.0-beta.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.0-beta.3) (2016-06-21)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.0-beta.2...v2.7.0-beta.3)
+## [v2.7.10](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.10) (2016-09-20)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.9...v2.7.10)
+
+**Closed issues:**
+
+- Deprecation warnings on Ember 2.8 [\#250](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/250)
+
+**Merged pull requests:**
+
+- Use Array.includes instead of deprecated contains if possible [\#251](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/251) ([mdentremont](https://github.com/mdentremont))
+
+## [v2.7.9](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.9) (2016-09-13)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.8...v2.7.9)
+
+**Closed issues:**
+
+- mockFind with RESTAdaptor clobbers type attribute on model [\#248](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/248)
+- Test Helpers in Factory break development build [\#247](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/247)
+
+## [v2.7.8](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.8) (2016-09-11)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.7...v2.7.8)
+
+**Closed issues:**
+
+- Manually adding model fragment causing error [\#244](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/244)
+
+## [v2.7.7](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.7) (2016-09-08)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.6...v2.7.7)
+
+**Closed issues:**
+
+- Having a property called "type" on your model causes `make` to fail [\#242](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/242)
+- Mock URL matching not working with query params [\#239](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/239)
+
+## [v2.7.6](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.6) (2016-09-06)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.5...v2.7.6)
+
+**Closed issues:**
+
+- Mocking a singularized endpoint [\#241](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/241)
+- You can no longer create model fragments on their own using make or makeList [\#238](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/238)
+- Field called type raises error [\#237](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/237)
+- FactoryGuy.define devours the supplied config object [\#235](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/235)
+- Build strategies for related data [\#234](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/234)
+- Latest change in 2.7.4 breaks models that have an attribute `type` [\#233](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/233)
+
+**Merged pull requests:**
+
+- Added test to check url matching of mockDelete and mockUpdate [\#240](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/240) ([danielspaniel](https://github.com/adopted-ember-addons))
+- es6 args destructuring removed from public api on mocks [\#236](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/236) ([youroff](https://github.com/youroff))
+
+## [v2.7.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.5) (2016-08-25)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.4...v2.7.5)
+
+**Closed issues:**
+
+- Bizarre issue with make and makeList [\#232](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/232)
+- Returning inherited models of various types [\#231](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/231)
+- How to mock requests to custom endpoints in integration test [\#230](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/230)
+- TypeError: uri.path is not a function [\#225](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/225)
+
+## [v2.7.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.4) (2016-08-22)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.3...v2.7.4)
+
+**Closed issues:**
+
+- mockFindAll, mockQuery, etc weird behavior with fails [\#224](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/224)
+- Strange behavior when using custom serializers [\#223](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/223)
+- A typo in scenario.js [\#222](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/222)
+
+**Merged pull requests:**
+
+- Update README to reflect mockTeardown\(\) usage in component tests [\#229](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/229) ([oniofchaos](https://github.com/oniofchaos))
+- disable\(\), enable\(\), and destroy\(\) methods for mocks [\#228](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/228) ([ryedeer](https://github.com/ryedeer))
+- withSomeParams modifier for mockGetRequest [\#227](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/227) ([youroff](https://github.com/youroff))
+
+## [v2.7.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.3) (2016-08-01)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.2...v2.7.3)
+
+## [v2.7.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.2) (2016-07-26)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.1...v2.7.2)
+
+**Closed issues:**
+
+- Non-integer primary keys are forced to the model's `id` during make/build [\#220](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/220)
+
+**Merged pull requests:**
+
+- mockFind does not return a failed response [\#221](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/221) ([daibhin](https://github.com/daibhin))
+
+## [v2.7.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.1) (2016-07-13)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.0...v2.7.1)
+
+**Closed issues:**
+
+- \[FEATURE REQUEST\] Add support for serializer renamed fields \(ie: `attrs: { localKey: 'serverKey'}`\) [\#219](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/219)
+
+## [v2.7.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.0) (2016-07-12)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.0-beta.11...v2.7.0)
+
+**Closed issues:**
+
+- Make throws a registry.resolve error [\#218](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/218)
+
+## [v2.7.0-beta.11](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.0-beta.11) (2016-07-08)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.0-beta.10...v2.7.0-beta.11)
+
+**Closed issues:**
+
+- .match\(\) for mockUpdate\(\) [\#216](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/216)
+
+## [v2.7.0-beta.10](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.0-beta.10) (2016-07-07)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.0-beta.9...v2.7.0-beta.10)
 
 **Implemented enhancements:**
 
-- Make Factory Guy available in development  [\#206](https://github.com/danielspaniel/ember-data-factory-guy/issues/206)
-
-## [v2.7.0-beta.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.0-beta.2) (2016-06-18)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.7.0-beta.1...v2.7.0-beta.2)
-
-## [v2.7.0-beta.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.7.0-beta.1) (2016-06-18)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.6.7...v2.7.0-beta.1)
+- Fix =\> DEPRECATION: `InvalidError` expects json-api formatted errors. [\#123](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/123)
 
 **Closed issues:**
 
-- Make vs build, debugging mockjax requests [\#210](https://github.com/danielspaniel/ember-data-factory-guy/issues/210)
+- fails\(\)'s convertResponseErrors\(\) doesn't allow for using error 'meta' property or returning exact response passed [\#215](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/215)
 
 **Merged pull requests:**
 
-- Adding factories to the app instead [\#211](https://github.com/danielspaniel/ember-data-factory-guy/pull/211) ([taras](https://github.com/taras))
+- Tests for mockUpdate.match \#216 [\#217](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/217) ([cristinawithout](https://github.com/cristinawithout))
 
-## [v2.6.7](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.6.7) (2016-06-15)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.6.6...v2.6.7)
+## [v2.7.0-beta.9](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.0-beta.9) (2016-07-04)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.0-beta.8...v2.7.0-beta.9)
 
 **Closed issues:**
 
-- 'undefined' is not a function \(evaluating 'factoryGuy.make.bind\(factoryGuy\)'\) [\#208](https://github.com/danielspaniel/ember-data-factory-guy/issues/208)
+- match\(\) fails with JSONAPI for relationship when serializer's payloadKeyFromModelName\(\) doesn't pluralize [\#213](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/213)
+
+## [v2.7.0-beta.8](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.0-beta.8) (2016-06-30)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.0-beta.7...v2.7.0-beta.8)
 
 **Merged pull requests:**
 
-- Make more resilient about adding query parameters at levels below Ember [\#209](https://github.com/danielspaniel/ember-data-factory-guy/pull/209) ([YoranBrondsema](https://github.com/YoranBrondsema))
+- Issue 213 jsonapi payloadkey [\#214](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/214) ([cristinawithout](https://github.com/cristinawithout))
 
-## [v2.6.6](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.6.6) (2016-06-01)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.6.5...v2.6.6)
+## [v2.7.0-beta.7](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.0-beta.7) (2016-06-28)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.0-beta.6...v2.7.0-beta.7)
 
-**Closed issues:**
+## [v2.7.0-beta.6](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.0-beta.6) (2016-06-27)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.0-beta.5...v2.7.0-beta.6)
 
-- ActiveModel sideload or a mockQuery update/create variant [\#205](https://github.com/danielspaniel/ember-data-factory-guy/issues/205)
+## [v2.7.0-beta.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.0-beta.5) (2016-06-23)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.0-beta.4...v2.7.0-beta.5)
 
-## [v2.6.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.6.5) (2016-05-31)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.6.4...v2.6.5)
+## [v2.7.0-beta.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.0-beta.4) (2016-06-23)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.0-beta.3...v2.7.0-beta.4)
 
-**Closed issues:**
-
-- Proposal - add mockDeleteAny [\#201](https://github.com/danielspaniel/ember-data-factory-guy/issues/201)
-- using .andFail with a status that isn't an error code [\#115](https://github.com/danielspaniel/ember-data-factory-guy/issues/115)
-
-## [v2.6.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.6.4) (2016-05-28)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.6.3...v2.6.4)
-
-**Merged pull requests:**
-
-- Add support for deleting any model to mockDelete [\#207](https://github.com/danielspaniel/ember-data-factory-guy/pull/207) ([mattmcginnis](https://github.com/mattmcginnis))
-
-## [v2.6.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.6.3) (2016-05-27)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.6.2...v2.6.3)
-
-**Closed issues:**
-
-- handleCreate does not allow response to include nested associations [\#172](https://github.com/danielspaniel/ember-data-factory-guy/issues/172)
-- handleCreate\(\).match does not work with ActiveModelSerializer [\#165](https://github.com/danielspaniel/ember-data-factory-guy/issues/165)
-- handleCreate does not mock response with relationships [\#141](https://github.com/danielspaniel/ember-data-factory-guy/issues/141)
-
-## [v2.6.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.6.2) (2016-05-26)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.6.1...v2.6.2)
-
-**Closed issues:**
-
-- Custom API format section of README is out of date [\#195](https://github.com/danielspaniel/ember-data-factory-guy/issues/195)
-
-**Merged pull requests:**
-
-- Delete LICENSE [\#203](https://github.com/danielspaniel/ember-data-factory-guy/pull/203) ([oniofchaos](https://github.com/oniofchaos))
-- Update README.md [\#202](https://github.com/danielspaniel/ember-data-factory-guy/pull/202) ([oniofchaos](https://github.com/oniofchaos))
-
-## [v2.6.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.6.1) (2016-05-20)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.6.0...v2.6.1)
-
-## [v2.6.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.6.0) (2016-05-15)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.5.6...v2.6.0)
-
-**Closed issues:**
-
-- Error due to primaryKey in serializer [\#198](https://github.com/danielspaniel/ember-data-factory-guy/issues/198)
-
-## [v2.5.6](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.5.6) (2016-05-12)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.5.5...v2.5.6)
-
-**Closed issues:**
-
-- Model named "computed" is not found. [\#197](https://github.com/danielspaniel/ember-data-factory-guy/issues/197)
-- "getModelPayload isProxy get add unwrap".w is not a function [\#196](https://github.com/danielspaniel/ember-data-factory-guy/issues/196)
-
-**Merged pull requests:**
-
-- Support embedding records using `deserialize: 'records'` [\#200](https://github.com/danielspaniel/ember-data-factory-guy/pull/200) ([patocallaghan](https://github.com/patocallaghan))
-- Add support for primaryKey in serializers [\#199](https://github.com/danielspaniel/ember-data-factory-guy/pull/199) ([mattmcginnis](https://github.com/mattmcginnis))
-
-## [v2.5.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.5.5) (2016-05-09)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.5.4...v2.5.5)
-
-## [v2.5.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.5.4) (2016-05-09)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.5.3...v2.5.4)
-
-**Merged pull requests:**
-
-- Updated README with documentation about using ember-data-model-fragments [\#194](https://github.com/danielspaniel/ember-data-factory-guy/pull/194) ([patocallaghan](https://github.com/patocallaghan))
-
-## [v2.5.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.5.3) (2016-05-03)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.5.2...v2.5.3)
-
-**Merged pull requests:**
-
-- Fix type.match crasher [\#193](https://github.com/danielspaniel/ember-data-factory-guy/pull/193) ([patocallaghan](https://github.com/patocallaghan))
-
-## [v2.5.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.5.2) (2016-05-01)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.5.1...v2.5.2)
-
-**Closed issues:**
-
-- how to know if mock request was sent? [\#186](https://github.com/danielspaniel/ember-data-factory-guy/issues/186)
-
-## [v2.5.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.5.1) (2016-05-01)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.5.0...v2.5.1)
-
-## [v2.5.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.5.0) (2016-05-01)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.4.5...v2.5.0)
-
-**Merged pull requests:**
-
-- Added tests for Ember Data Model Fragment factory support in unit tests [\#188](https://github.com/danielspaniel/ember-data-factory-guy/pull/188) ([patocallaghan](https://github.com/patocallaghan))
-
-## [v2.4.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.4.5) (2016-04-21)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.4.4...v2.4.5)
-
-**Merged pull requests:**
-
-- Wrap arrays that use prototype extensions in Ember.A\(\) [\#192](https://github.com/danielspaniel/ember-data-factory-guy/pull/192) ([gilest](https://github.com/gilest))
-- refactor the equivalence function so that it works with arrays as well [\#191](https://github.com/danielspaniel/ember-data-factory-guy/pull/191) ([bryanaka](https://github.com/bryanaka))
-- Add changelog [\#190](https://github.com/danielspaniel/ember-data-factory-guy/pull/190) ([Robdel12](https://github.com/Robdel12))
-- Fix deprecation warning Ember.merge \> Ember.assign for ember@2.5.0 [\#189](https://github.com/danielspaniel/ember-data-factory-guy/pull/189) ([krasnoukhov](https://github.com/krasnoukhov))
-- Handle active model formatted request data properly [\#187](https://github.com/danielspaniel/ember-data-factory-guy/pull/187) ([ccleung](https://github.com/ccleung))
-
-## [v2.4.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.4.4) (2016-03-26)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.4.3...v2.4.4)
-
-**Closed issues:**
-
-- Embedded records always sideloaded [\#183](https://github.com/danielspaniel/ember-data-factory-guy/issues/183)
-- Compatibility with ember-data-model-fragments [\#182](https://github.com/danielspaniel/ember-data-factory-guy/issues/182)
-- Store empty after using makeList [\#147](https://github.com/danielspaniel/ember-data-factory-guy/issues/147)
-
-**Merged pull requests:**
-
-- Fix compatibility with ember-data-model-fragments [\#184](https://github.com/danielspaniel/ember-data-factory-guy/pull/184) ([whatthewhat](https://github.com/whatthewhat))
-
-## [v2.4.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.4.3) (2016-03-24)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.4.2...v2.4.3)
-
-## [v2.4.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.4.2) (2016-03-19)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.4.1...v2.4.2)
-
-**Closed issues:**
-
-- Crash when belongsTo is named 'event' [\#180](https://github.com/danielspaniel/ember-data-factory-guy/issues/180)
-- Can we replace `new Set\(\)` to Object? [\#179](https://github.com/danielspaniel/ember-data-factory-guy/issues/179)
-
-**Merged pull requests:**
-
-- Update jquery-mockjax to 2.1.1 [\#181](https://github.com/danielspaniel/ember-data-factory-guy/pull/181) ([YoranBrondsema](https://github.com/YoranBrondsema))
-
-## [v2.4.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.4.1) (2016-03-09)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.4.0...v2.4.1)
-
-## [v2.4.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.4.0) (2016-03-07)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.3.3...v2.4.0)
-
-**Closed issues:**
-
-- Cannot read property 'call' of undefined with empty factory... [\#178](https://github.com/danielspaniel/ember-data-factory-guy/issues/178)
-
-## [v2.3.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.3.3) (2016-03-04)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.3.2...v2.3.3)
-
-**Closed issues:**
-
-- Confusing behavior with handleQuery related to setup and teardown in acceptance test [\#164](https://github.com/danielspaniel/ember-data-factory-guy/issues/164)
-- Underlying network request not mocked [\#137](https://github.com/danielspaniel/ember-data-factory-guy/issues/137)
-- Suggestion: Multiple handleFindAll calls should override the previous mock [\#132](https://github.com/danielspaniel/ember-data-factory-guy/issues/132)
-- Error when an App is teared down with App.destroy [\#104](https://github.com/danielspaniel/ember-data-factory-guy/issues/104)
-
-## [v2.3.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.3.2) (2016-03-03)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.3.1...v2.3.2)
-
-**Closed issues:**
-
-- makeList fails trying to read a number as a trait [\#177](https://github.com/danielspaniel/ember-data-factory-guy/issues/177)
-
-## [v2.3.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.3.1) (2016-03-02)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.3.0...v2.3.1)
+## [v2.7.0-beta.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.0-beta.3) (2016-06-21)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.0-beta.2...v2.7.0-beta.3)
 
 **Implemented enhancements:**
 
-- Full control over handler [\#159](https://github.com/danielspaniel/ember-data-factory-guy/issues/159)
-- customise response Headers as well as payloads [\#158](https://github.com/danielspaniel/ember-data-factory-guy/issues/158)
-- Mocks: andSucceed/andFail everywhere [\#157](https://github.com/danielspaniel/ember-data-factory-guy/issues/157)
+- Make Factory Guy available in development  [\#206](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/206)
 
-## [v2.3.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.3.0) (2016-03-02)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.2.0...v2.3.0)
+## [v2.7.0-beta.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.0-beta.2) (2016-06-18)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.7.0-beta.1...v2.7.0-beta.2)
 
-**Closed issues:**
-
-- handleQuery not working as expected in acceptance test [\#174](https://github.com/danielspaniel/ember-data-factory-guy/issues/174)
-- How do I test `store.filter` [\#118](https://github.com/danielspaniel/ember-data-factory-guy/issues/118)
-
-## [v2.2.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.2.0) (2016-02-19)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.1.6...v2.2.0)
-
-## [v2.1.6](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.1.6) (2016-02-14)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.1.5...v2.1.6)
-
-## [v2.1.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.1.5) (2016-02-12)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.1.4...v2.1.5)
+## [v2.7.0-beta.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.7.0-beta.1) (2016-06-18)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.6.7...v2.7.0-beta.1)
 
 **Closed issues:**
 
-- How to use with integration tests? [\#171](https://github.com/danielspaniel/ember-data-factory-guy/issues/171)
+- Make vs build, debugging mockjax requests [\#210](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/210)
 
 **Merged pull requests:**
 
-- Return fixture relationship IDs if not an object \(fix \#166\) [\#167](https://github.com/danielspaniel/ember-data-factory-guy/pull/167) ([mmelvin0](https://github.com/mmelvin0))
+- Adding factories to the app instead [\#211](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/211) ([taras](https://github.com/taras))
 
-## [v2.1.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.1.4) (2016-01-23)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.1.3...v2.1.4)
+## [v2.6.7](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.6.7) (2016-06-15)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.6.6...v2.6.7)
 
 **Closed issues:**
 
-- Installing with Ember-CLI 2.2.0.beta.3 doesn't install bower dependencies  [\#170](https://github.com/danielspaniel/ember-data-factory-guy/issues/170)
-- FactoryGuy.make\(\) doesn't handle ID relationships, Ember Data does [\#166](https://github.com/danielspaniel/ember-data-factory-guy/issues/166)
-- Using handleQuery for the same endpoint with different query params [\#151](https://github.com/danielspaniel/ember-data-factory-guy/issues/151)
-- Buggette with cheese - extractAttributes 0 should not be false [\#146](https://github.com/danielspaniel/ember-data-factory-guy/issues/146)
-- How should I handle a full scenario involving handleCreate and store.query? [\#143](https://github.com/danielspaniel/ember-data-factory-guy/issues/143)
+- 'undefined' is not a function \(evaluating 'factoryGuy.make.bind\(factoryGuy\)'\) [\#208](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/208)
 
 **Merged pull requests:**
 
-- build\(\): apply transform of custom type when serializing attributes [\#173](https://github.com/danielspaniel/ember-data-factory-guy/pull/173) ([kemenaran](https://github.com/kemenaran))
-- Supporting nested query params comparisons in handleQuery [\#169](https://github.com/danielspaniel/ember-data-factory-guy/pull/169) ([gleseur](https://github.com/gleseur))
-- Added video to your introduction [\#168](https://github.com/danielspaniel/ember-data-factory-guy/pull/168) ([taras](https://github.com/taras))
+- Make more resilient about adding query parameters at levels below Ember [\#209](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/209) ([YoranBrondsema](https://github.com/YoranBrondsema))
 
-## [v2.1.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.1.3) (2015-12-16)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.1.2...v2.1.3)
+## [v2.6.6](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.6.6) (2016-06-01)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.6.5...v2.6.6)
 
 **Closed issues:**
 
-- Proposal - Response configuration \(headers...\) [\#156](https://github.com/danielspaniel/ember-data-factory-guy/issues/156)
-- final production build include full ember-data-factory-guy library in vendor.js [\#140](https://github.com/danielspaniel/ember-data-factory-guy/issues/140)
+- ActiveModel sideload or a mockQuery update/create variant [\#205](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/205)
+
+## [v2.6.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.6.5) (2016-05-31)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.6.4...v2.6.5)
+
+**Closed issues:**
+
+- Proposal - add mockDeleteAny [\#201](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/201)
+- using .andFail with a status that isn't an error code [\#115](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/115)
+
+## [v2.6.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.6.4) (2016-05-28)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.6.3...v2.6.4)
 
 **Merged pull requests:**
 
-- Production build does not include factory guy [\#163](https://github.com/danielspaniel/ember-data-factory-guy/pull/163) ([afn](https://github.com/afn))
-- Deprecates options succeed [\#162](https://github.com/danielspaniel/ember-data-factory-guy/pull/162) ([xcambar](https://github.com/xcambar))
-- handleFindAll\(\) and buildList\(\) can make diverse models [\#161](https://github.com/danielspaniel/ember-data-factory-guy/pull/161) ([afn](https://github.com/afn))
-- Super critical fix [\#155](https://github.com/danielspaniel/ember-data-factory-guy/pull/155) ([orf](https://github.com/orf))
-- No more useJSONAPI [\#154](https://github.com/danielspaniel/ember-data-factory-guy/pull/154) ([xcambar](https://github.com/xcambar))
+- Add support for deleting any model to mockDelete [\#207](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/207) ([mattmcginnis](https://github.com/mattmcginnis))
 
-## [v2.1.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.1.2) (2015-12-05)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.1.1...v2.1.2)
+## [v2.6.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.6.3) (2016-05-27)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.6.2...v2.6.3)
 
 **Closed issues:**
 
-- custom adapter? [\#150](https://github.com/danielspaniel/ember-data-factory-guy/issues/150)
-- Allow 'custom' response on `handle...` calls [\#139](https://github.com/danielspaniel/ember-data-factory-guy/issues/139)
+- handleCreate does not allow response to include nested associations [\#172](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/172)
+- handleCreate\(\).match does not work with ActiveModelSerializer [\#165](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/165)
+- handleCreate does not mock response with relationships [\#141](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/141)
+
+## [v2.6.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.6.2) (2016-05-26)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.6.1...v2.6.2)
+
+**Closed issues:**
+
+- Custom API format section of README is out of date [\#195](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/195)
 
 **Merged pull requests:**
 
-- Removes legacy getStore method [\#153](https://github.com/danielspaniel/ember-data-factory-guy/pull/153) ([xcambar](https://github.com/xcambar))
-- Allows to customize the FixtureBuilder [\#152](https://github.com/danielspaniel/ember-data-factory-guy/pull/152) ([xcambar](https://github.com/xcambar))
-- Fix jquery-mockjax bower package addition to Project [\#148](https://github.com/danielspaniel/ember-data-factory-guy/pull/148) ([anilmaurya](https://github.com/anilmaurya))
+- Delete LICENSE [\#203](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/203) ([oniofchaos](https://github.com/oniofchaos))
+- Update README.md [\#202](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/202) ([oniofchaos](https://github.com/oniofchaos))
 
-## [v2.1.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.1.1) (2015-11-02)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.1.0...v2.1.1)
+## [v2.6.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.6.1) (2016-05-20)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.6.0...v2.6.1)
+
+## [v2.6.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.6.0) (2016-05-15)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.5.6...v2.6.0)
 
 **Closed issues:**
 
-- Can't find that factory named ... [\#142](https://github.com/danielspaniel/ember-data-factory-guy/issues/142)
-- Q: Association based data [\#138](https://github.com/danielspaniel/ember-data-factory-guy/issues/138)
+- Error due to primaryKey in serializer [\#198](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/198)
+
+## [v2.5.6](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.5.6) (2016-05-12)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.5.5...v2.5.6)
+
+**Closed issues:**
+
+- Model named "computed" is not found. [\#197](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/197)
+- "getModelPayload isProxy get add unwrap".w is not a function [\#196](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/196)
 
 **Merged pull requests:**
 
-- Attribute typing [\#145](https://github.com/danielspaniel/ember-data-factory-guy/pull/145) ([wismer](https://github.com/wismer))
+- Support embedding records using `deserialize: 'records'` [\#200](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/200) ([patocallaghan](https://github.com/patocallaghan))
+- Add support for primaryKey in serializers [\#199](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/199) ([mattmcginnis](https://github.com/mattmcginnis))
 
-## [v2.1.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.1.0) (2015-10-06)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.0.3...v2.1.0)
+## [v2.5.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.5.5) (2016-05-09)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.5.4...v2.5.5)
 
-**Closed issues:**
-
-- findRecord giving error "Cannot read property '\_internalModel' of undefined" [\#136](https://github.com/danielspaniel/ember-data-factory-guy/issues/136)
-- setStore error [\#135](https://github.com/danielspaniel/ember-data-factory-guy/issues/135)
-- handleFindAll\(\) mockjax return always includes embedded reccords [\#134](https://github.com/danielspaniel/ember-data-factory-guy/issues/134)
-- 1.13.10 mockjax not working: Cannot set property 'logging' of undefined [\#133](https://github.com/danielspaniel/ember-data-factory-guy/issues/133)
-- Issues Getting Started [\#131](https://github.com/danielspaniel/ember-data-factory-guy/issues/131)
-- payload of handleFind limited to record's typeKey [\#82](https://github.com/danielspaniel/ember-data-factory-guy/issues/82)
-
-## [v2.0.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.0.3) (2015-09-04)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.0.2...v2.0.3)
-
-**Closed issues:**
-
-- dependancy on jQuery^2.1 [\#130](https://github.com/danielspaniel/ember-data-factory-guy/issues/130)
-
-## [v2.0.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.0.2) (2015-09-04)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.0.1...v2.0.2)
-
-**Closed issues:**
-
-- handleFindAll not playing well with handleUpdate [\#128](https://github.com/danielspaniel/ember-data-factory-guy/issues/128)
-- Determining which adapter is being used no workie [\#127](https://github.com/danielspaniel/ember-data-factory-guy/issues/127)
-- handleFindQuery doesn't make use of query parameters [\#126](https://github.com/danielspaniel/ember-data-factory-guy/issues/126)
-- testHelper handleFindAll cannot handle RESTAdapter relationships [\#113](https://github.com/danielspaniel/ember-data-factory-guy/issues/113)
+## [v2.5.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.5.4) (2016-05-09)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.5.3...v2.5.4)
 
 **Merged pull requests:**
 
-- update README for handleFindAll [\#129](https://github.com/danielspaniel/ember-data-factory-guy/pull/129) ([eliotpiering](https://github.com/eliotpiering))
+- Updated README with documentation about using ember-data-model-fragments [\#194](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/194) ([patocallaghan](https://github.com/patocallaghan))
 
-## [v2.0.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.0.1) (2015-09-02)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v2.0.0...v2.0.1)
+## [v2.5.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.5.3) (2016-05-03)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.5.2...v2.5.3)
+
+**Merged pull requests:**
+
+- Fix type.match crasher [\#193](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/193) ([patocallaghan](https://github.com/patocallaghan))
+
+## [v2.5.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.5.2) (2016-05-01)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.5.1...v2.5.2)
 
 **Closed issues:**
 
-- jquery-mockjax is enabled in development as well as test environment [\#124](https://github.com/danielspaniel/ember-data-factory-guy/issues/124)
+- how to know if mock request was sent? [\#186](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/186)
 
-## [v2.0.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v2.0.0) (2015-08-29)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.13.10...v2.0.0)
+## [v2.5.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.5.1) (2016-05-01)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.5.0...v2.5.1)
 
-## [v1.13.10](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.13.10) (2015-08-28)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.13.9...v1.13.10)
+## [v2.5.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.5.0) (2016-05-01)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.4.5...v2.5.0)
 
-## [v1.13.9](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.13.9) (2015-08-24)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.13.8...v1.13.9)
+**Merged pull requests:**
+
+- Added tests for Ember Data Model Fragment factory support in unit tests [\#188](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/188) ([patocallaghan](https://github.com/patocallaghan))
+
+## [v2.4.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.4.5) (2016-04-21)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.4.4...v2.4.5)
+
+**Merged pull requests:**
+
+- Wrap arrays that use prototype extensions in Ember.A\(\) [\#192](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/192) ([gilest](https://github.com/gilest))
+- refactor the equivalence function so that it works with arrays as well [\#191](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/191) ([bryanaka](https://github.com/bryanaka))
+- Add changelog [\#190](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/190) ([Robdel12](https://github.com/Robdel12))
+- Fix deprecation warning Ember.merge \> Ember.assign for ember@2.5.0 [\#189](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/189) ([krasnoukhov](https://github.com/krasnoukhov))
+- Handle active model formatted request data properly [\#187](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/187) ([ccleung](https://github.com/ccleung))
+
+## [v2.4.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.4.4) (2016-03-26)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.4.3...v2.4.4)
+
+**Closed issues:**
+
+- Embedded records always sideloaded [\#183](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/183)
+- Compatibility with ember-data-model-fragments [\#182](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/182)
+- Store empty after using makeList [\#147](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/147)
+
+**Merged pull requests:**
+
+- Fix compatibility with ember-data-model-fragments [\#184](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/184) ([whatthewhat](https://github.com/whatthewhat))
+
+## [v2.4.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.4.3) (2016-03-24)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.4.2...v2.4.3)
+
+## [v2.4.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.4.2) (2016-03-19)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.4.1...v2.4.2)
+
+**Closed issues:**
+
+- Crash when belongsTo is named 'event' [\#180](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/180)
+- Can we replace `new Set\(\)` to Object? [\#179](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/179)
+
+**Merged pull requests:**
+
+- Update jquery-mockjax to 2.1.1 [\#181](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/181) ([YoranBrondsema](https://github.com/YoranBrondsema))
+
+## [v2.4.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.4.1) (2016-03-09)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.4.0...v2.4.1)
+
+## [v2.4.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.4.0) (2016-03-07)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.3.3...v2.4.0)
+
+**Closed issues:**
+
+- Cannot read property 'call' of undefined with empty factory... [\#178](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/178)
+
+## [v2.3.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.3.3) (2016-03-04)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.3.2...v2.3.3)
+
+**Closed issues:**
+
+- Confusing behavior with handleQuery related to setup and teardown in acceptance test [\#164](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/164)
+- Underlying network request not mocked [\#137](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/137)
+- Suggestion: Multiple handleFindAll calls should override the previous mock [\#132](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/132)
+- Error when an App is teared down with App.destroy [\#104](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/104)
+
+## [v2.3.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.3.2) (2016-03-03)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.3.1...v2.3.2)
+
+**Closed issues:**
+
+- makeList fails trying to read a number as a trait [\#177](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/177)
+
+## [v2.3.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.3.1) (2016-03-02)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.3.0...v2.3.1)
 
 **Implemented enhancements:**
 
-- change handleFind to handleReload and make handleFind actually handle find [\#99](https://github.com/danielspaniel/ember-data-factory-guy/issues/99)
+- Full control over handler [\#159](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/159)
+- customise response Headers as well as payloads [\#158](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/158)
+- Mocks: andSucceed/andFail everywhere [\#157](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/157)
+
+## [v2.3.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.3.0) (2016-03-02)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.2.0...v2.3.0)
 
 **Closed issues:**
 
-- JSON API attribute name conversion when using a custom application serializer [\#116](https://github.com/danielspaniel/ember-data-factory-guy/issues/116)
-- Simplify the find stub for one record [\#112](https://github.com/danielspaniel/ember-data-factory-guy/issues/112)
+- handleQuery not working as expected in acceptance test [\#174](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/174)
+- How do I test `store.filter` [\#118](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/118)
+
+## [v2.2.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.2.0) (2016-02-19)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.1.6...v2.2.0)
+
+## [v2.1.6](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.1.6) (2016-02-14)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.1.5...v2.1.6)
+
+## [v2.1.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.1.5) (2016-02-12)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.1.4...v2.1.5)
+
+**Closed issues:**
+
+- How to use with integration tests? [\#171](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/171)
 
 **Merged pull requests:**
 
-- Changed how to determine if mockjax should be loaded [\#125](https://github.com/danielspaniel/ember-data-factory-guy/pull/125) ([begedin](https://github.com/begedin))
+- Return fixture relationship IDs if not an object \(fix \#166\) [\#167](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/167) ([mmelvin0](https://github.com/mmelvin0))
 
-## [v1.13.8](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.13.8) (2015-08-21)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.13.7...v1.13.8)
+## [v2.1.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.1.4) (2016-01-23)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.1.3...v2.1.4)
 
 **Closed issues:**
 
-- Can the handler functions deal with non-rest adapters? [\#121](https://github.com/danielspaniel/ember-data-factory-guy/issues/121)
-- Could not find module `active-model-adapter`  [\#120](https://github.com/danielspaniel/ember-data-factory-guy/issues/120)
+- Installing with Ember-CLI 2.2.0.beta.3 doesn't install bower dependencies  [\#170](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/170)
+- FactoryGuy.make\(\) doesn't handle ID relationships, Ember Data does [\#166](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/166)
+- Using handleQuery for the same endpoint with different query params [\#151](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/151)
+- Buggette with cheese - extractAttributes 0 should not be false [\#146](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/146)
+- How should I handle a full scenario involving handleCreate and store.query? [\#143](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/143)
 
 **Merged pull requests:**
 
-- Allow usage of applications serializer to transform attributes [\#122](https://github.com/danielspaniel/ember-data-factory-guy/pull/122) ([begedin](https://github.com/begedin))
+- build\(\): apply transform of custom type when serializing attributes [\#173](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/173) ([kemenaran](https://github.com/kemenaran))
+- Supporting nested query params comparisons in handleQuery [\#169](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/169) ([gleseur](https://github.com/gleseur))
+- Added video to your introduction [\#168](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/168) ([taras](https://github.com/taras))
 
-## [v1.13.7](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.13.7) (2015-08-17)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.13.6...v1.13.7)
-
-## [v1.13.6](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.13.6) (2015-08-11)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.13.5...v1.13.6)
+## [v2.1.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.1.3) (2015-12-16)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.1.2...v2.1.3)
 
 **Closed issues:**
 
-- setStore needs a valid store instance [\#117](https://github.com/danielspaniel/ember-data-factory-guy/issues/117)
-- Building data attributes for JSONAPIAdapter not working as expected [\#108](https://github.com/danielspaniel/ember-data-factory-guy/issues/108)
+- Proposal - Response configuration \(headers...\) [\#156](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/156)
+- final production build include full ember-data-factory-guy library in vendor.js [\#140](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/140)
 
 **Merged pull requests:**
 
-- Ember 2.0 fixes [\#119](https://github.com/danielspaniel/ember-data-factory-guy/pull/119) ([mcm-ham](https://github.com/mcm-ham))
+- Production build does not include factory guy [\#163](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/163) ([afn](https://github.com/afn))
+- Deprecates options succeed [\#162](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/162) ([xcambar](https://github.com/xcambar))
+- handleFindAll\(\) and buildList\(\) can make diverse models [\#161](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/161) ([afn](https://github.com/afn))
+- Super critical fix [\#155](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/155) ([orf](https://github.com/orf))
+- No more useJSONAPI [\#154](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/154) ([xcambar](https://github.com/xcambar))
 
-## [v1.13.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.13.5) (2015-08-04)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.13.4...v1.13.5)
-
-## [v1.13.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.13.4) (2015-08-03)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.13.3...v1.13.4)
-
-**Closed issues:**
-
-- handleFindAll with no records [\#109](https://github.com/danielspaniel/ember-data-factory-guy/issues/109)
-
-## [v1.13.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.13.3) (2015-07-30)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.13.2...v1.13.3)
+## [v2.1.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.1.2) (2015-12-05)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.1.1...v2.1.2)
 
 **Closed issues:**
 
-- handleFindAll does not work and makeList works [\#111](https://github.com/danielspaniel/ember-data-factory-guy/issues/111)
-- invalid 'instanceof' operand DS.default.JSONAPIAdapter [\#110](https://github.com/danielspaniel/ember-data-factory-guy/issues/110)
-- Allow handleFindAll to return 0 items [\#107](https://github.com/danielspaniel/ember-data-factory-guy/issues/107)
+- custom adapter? [\#150](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/150)
+- Allow 'custom' response on `handle...` calls [\#139](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/139)
 
 **Merged pull requests:**
 
-- Work without prototype extensions [\#114](https://github.com/danielspaniel/ember-data-factory-guy/pull/114) ([indirect](https://github.com/indirect))
+- Removes legacy getStore method [\#153](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/153) ([xcambar](https://github.com/xcambar))
+- Allows to customize the FixtureBuilder [\#152](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/152) ([xcambar](https://github.com/xcambar))
+- Fix jquery-mockjax bower package addition to Project [\#148](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/148) ([anilmaurya](https://github.com/anilmaurya))
 
-## [v1.13.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.13.2) (2015-07-14)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.13.1...v1.13.2)
+## [v2.1.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.1.1) (2015-11-02)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.1.0...v2.1.1)
 
 **Closed issues:**
 
-- Couldn't find module after installing ember-data-factory-guy 1.13.0 [\#103](https://github.com/danielspaniel/ember-data-factory-guy/issues/103)
+- Can't find that factory named ... [\#142](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/142)
+- Q: Association based data [\#138](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/138)
 
 **Merged pull requests:**
 
-- Fix DEPRECATION: Ember.keys is deprecated in favor of Object.keys [\#106](https://github.com/danielspaniel/ember-data-factory-guy/pull/106) ([jcope2013](https://github.com/jcope2013))
-- add note to avoid using ember-data-1.0.0-beta.19.2 [\#105](https://github.com/danielspaniel/ember-data-factory-guy/pull/105) ([raycohen](https://github.com/raycohen))
+- Attribute typing [\#145](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/145) ([wismer](https://github.com/wismer))
 
-## [v1.13.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.13.1) (2015-07-01)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.13.0...v1.13.1)
+## [v2.1.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.1.0) (2015-10-06)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.0.3...v2.1.0)
+
+**Closed issues:**
+
+- findRecord giving error "Cannot read property '\_internalModel' of undefined" [\#136](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/136)
+- setStore error [\#135](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/135)
+- handleFindAll\(\) mockjax return always includes embedded reccords [\#134](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/134)
+- 1.13.10 mockjax not working: Cannot set property 'logging' of undefined [\#133](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/133)
+- Issues Getting Started [\#131](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/131)
+- payload of handleFind limited to record's typeKey [\#82](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/82)
+
+## [v2.0.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.0.3) (2015-09-04)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.0.2...v2.0.3)
+
+**Closed issues:**
+
+- dependancy on jQuery^2.1 [\#130](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/130)
+
+## [v2.0.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.0.2) (2015-09-04)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.0.1...v2.0.2)
+
+**Closed issues:**
+
+- handleFindAll not playing well with handleUpdate [\#128](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/128)
+- Determining which adapter is being used no workie [\#127](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/127)
+- handleFindQuery doesn't make use of query parameters [\#126](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/126)
+- testHelper handleFindAll cannot handle RESTAdapter relationships [\#113](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/113)
+
+**Merged pull requests:**
+
+- update README for handleFindAll [\#129](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/129) ([eliotpiering](https://github.com/eliotpiering))
+
+## [v2.0.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.0.1) (2015-09-02)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v2.0.0...v2.0.1)
+
+**Closed issues:**
+
+- jquery-mockjax is enabled in development as well as test environment [\#124](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/124)
+
+## [v2.0.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v2.0.0) (2015-08-29)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.13.10...v2.0.0)
+
+## [v1.13.10](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.13.10) (2015-08-28)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.13.9...v1.13.10)
+
+## [v1.13.9](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.13.9) (2015-08-24)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.13.8...v1.13.9)
 
 **Implemented enhancements:**
 
-- emit json-api document when building json by default [\#97](https://github.com/danielspaniel/ember-data-factory-guy/issues/97)
+- change handleFind to handleReload and make handleFind actually handle find [\#99](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/99)
 
 **Closed issues:**
 
-- version not found [\#102](https://github.com/danielspaniel/ember-data-factory-guy/issues/102)
-- Why reserved word 'default' as key [\#101](https://github.com/danielspaniel/ember-data-factory-guy/issues/101)
-
-## [v1.13.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.13.0) (2015-06-25)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.1.2...v1.13.0)
-
-## [v1.1.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.1.2) (2015-06-25)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.1.1...v1.1.2)
+- JSON API attribute name conversion when using a custom application serializer [\#116](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/116)
+- Simplify the find stub for one record [\#112](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/112)
 
 **Merged pull requests:**
 
-- Updates README.md to include Ember Observer Score [\#100](https://github.com/danielspaniel/ember-data-factory-guy/pull/100) ([gschorkopf](https://github.com/gschorkopf))
-- handleCreate now respects user-set id in andReturn [\#98](https://github.com/danielspaniel/ember-data-factory-guy/pull/98) ([slimeate](https://github.com/slimeate))
+- Changed how to determine if mockjax should be loaded [\#125](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/125) ([begedin](https://github.com/begedin))
 
-## [v1.1.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.1.1) (2015-06-17)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.1.0...v1.1.1)
+## [v1.13.8](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.13.8) (2015-08-21)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.13.7...v1.13.8)
+
+**Closed issues:**
+
+- Can the handler functions deal with non-rest adapters? [\#121](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/121)
+- Could not find module `active-model-adapter`  [\#120](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/120)
+
+**Merged pull requests:**
+
+- Allow usage of applications serializer to transform attributes [\#122](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/122) ([begedin](https://github.com/begedin))
+
+## [v1.13.7](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.13.7) (2015-08-17)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.13.6...v1.13.7)
+
+## [v1.13.6](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.13.6) (2015-08-11)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.13.5...v1.13.6)
+
+**Closed issues:**
+
+- setStore needs a valid store instance [\#117](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/117)
+- Building data attributes for JSONAPIAdapter not working as expected [\#108](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/108)
+
+**Merged pull requests:**
+
+- Ember 2.0 fixes [\#119](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/119) ([mcm-ham](https://github.com/mcm-ham))
+
+## [v1.13.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.13.5) (2015-08-04)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.13.4...v1.13.5)
+
+## [v1.13.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.13.4) (2015-08-03)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.13.3...v1.13.4)
+
+**Closed issues:**
+
+- handleFindAll with no records [\#109](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/109)
+
+## [v1.13.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.13.3) (2015-07-30)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.13.2...v1.13.3)
+
+**Closed issues:**
+
+- handleFindAll does not work and makeList works [\#111](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/111)
+- invalid 'instanceof' operand DS.default.JSONAPIAdapter [\#110](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/110)
+- Allow handleFindAll to return 0 items [\#107](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/107)
+
+**Merged pull requests:**
+
+- Work without prototype extensions [\#114](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/114) ([indirect](https://github.com/indirect))
+
+## [v1.13.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.13.2) (2015-07-14)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.13.1...v1.13.2)
+
+**Closed issues:**
+
+- Couldn't find module after installing ember-data-factory-guy 1.13.0 [\#103](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/103)
+
+**Merged pull requests:**
+
+- Fix DEPRECATION: Ember.keys is deprecated in favor of Object.keys [\#106](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/106) ([jcope2013](https://github.com/jcope2013))
+- add note to avoid using ember-data-1.0.0-beta.19.2 [\#105](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/105) ([raycohen](https://github.com/raycohen))
+
+## [v1.13.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.13.1) (2015-07-01)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.13.0...v1.13.1)
 
 **Implemented enhancements:**
 
-- thinking about allowing factories to extend others  [\#93](https://github.com/danielspaniel/ember-data-factory-guy/issues/93)
+- emit json-api document when building json by default [\#97](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/97)
 
 **Closed issues:**
 
-- Error: Assertion Failed: FactoryGuy\#setStore needs a valid store instance.You passed in \[undefined\] [\#94](https://github.com/danielspaniel/ember-data-factory-guy/issues/94)
-- Can't seem to use type as a property name [\#92](https://github.com/danielspaniel/ember-data-factory-guy/issues/92)
+- version not found [\#102](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/102)
+- Why reserved word 'default' as key [\#101](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/101)
 
-## [v1.1.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.1.0) (2015-06-15)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.0.12...v1.1.0)
+## [v1.13.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.13.0) (2015-06-25)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.1.2...v1.13.0)
 
-## [v1.0.12](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.0.12) (2015-06-11)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.0.11...v1.0.12)
-
-**Closed issues:**
-
-- Deprecation of `typeKey` in Ember Data [\#91](https://github.com/danielspaniel/ember-data-factory-guy/issues/91)
-
-## [v1.0.11](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.0.11) (2015-06-11)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.0.10...v1.0.11)
-
-**Closed issues:**
-
-- Not possible to mock multiple `save\(\)` calls with handleCreate [\#88](https://github.com/danielspaniel/ember-data-factory-guy/issues/88)
-- add .andFail\(\) option to handleFind\(\) [\#84](https://github.com/danielspaniel/ember-data-factory-guy/issues/84)
+## [v1.1.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.1.2) (2015-06-25)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.1.1...v1.1.2)
 
 **Merged pull requests:**
 
-- update store:main references to use store:application as store:main is now deprecated [\#90](https://github.com/danielspaniel/ember-data-factory-guy/pull/90) ([jcope2013](https://github.com/jcope2013))
-- Mocking a failed reload typo fix [\#89](https://github.com/danielspaniel/ember-data-factory-guy/pull/89) ([nummi](https://github.com/nummi))
+- Updates README.md to include Ember Observer Score [\#100](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/100) ([gschorkopf](https://github.com/gschorkopf))
+- handleCreate now respects user-set id in andReturn [\#98](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/98) ([slimeate](https://github.com/slimeate))
 
-## [v1.0.10](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.0.10) (2015-06-02)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.0.9...v1.0.10)
-
-**Closed issues:**
-
-- upgrade ember-cli to 0.2.5 [\#86](https://github.com/danielspaniel/ember-data-factory-guy/issues/86)
-
-## [v1.0.9](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.0.9) (2015-05-24)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.0.8...v1.0.9)
-
-**Closed issues:**
-
-- Install failure \(ember-cli 0.2.1\) [\#87](https://github.com/danielspaniel/ember-data-factory-guy/issues/87)
-
-**Merged pull requests:**
-
-- \[WIP\] Add andFail\(\) method to handleFind\(\) [\#85](https://github.com/danielspaniel/ember-data-factory-guy/pull/85) ([alexanderjeurissen](https://github.com/alexanderjeurissen))
-
-## [v1.0.8](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.0.8) (2015-05-08)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.0.7...v1.0.8)
-
-**Closed issues:**
-
-- Passing match to handleCreate results in false positive [\#81](https://github.com/danielspaniel/ember-data-factory-guy/issues/81)
-- FactoryGuy.hasMany fails with error `'undefined' is not an object \(evaluating 'traits\[trait\]'\)` [\#80](https://github.com/danielspaniel/ember-data-factory-guy/issues/80)
-
-**Merged pull requests:**
-
-- ignore autogenerated .jscs files [\#83](https://github.com/danielspaniel/ember-data-factory-guy/pull/83) ([GlennGeelen](https://github.com/GlennGeelen))
-
-## [v1.0.7](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.0.7) (2015-05-05)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.0.6...v1.0.7)
-
-**Closed issues:**
-
-- Dealing with multiple-inverse associations [\#57](https://github.com/danielspaniel/ember-data-factory-guy/issues/57)
-
-## [v1.0.6](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.0.6) (2015-04-29)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.0.5...v1.0.6)
-
-**Merged pull requests:**
-
-- Get this add-on working when prototype extensions are disabled in Ember [\#78](https://github.com/danielspaniel/ember-data-factory-guy/pull/78) ([chrisdpeters](https://github.com/chrisdpeters))
-
-## [v1.0.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.0.5) (2015-04-24)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.0.4...v1.0.5)
-
-**Closed issues:**
-
-- Multiple calls to handleCreate\(\) don't work [\#76](https://github.com/danielspaniel/ember-data-factory-guy/issues/76)
-
-**Merged pull requests:**
-
-- Fixed typo in readme [\#77](https://github.com/danielspaniel/ember-data-factory-guy/pull/77) ([kellyjensen](https://github.com/kellyjensen))
-
-## [v1.0.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.0.4) (2015-04-20)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.0.3...v1.0.4)
-
-**Closed issues:**
-
-- Using store.find, unable to find fixtures for model type \(subclass of DS.Model\). If you're defining your fixtures using `Model.FIXTURES = ...`, please change it to `Model.reopenClass\({ FIXTURES: ... }\)`. [\#75](https://github.com/danielspaniel/ember-data-factory-guy/issues/75)
-- Is not finding factories that are in tests/factories/ [\#74](https://github.com/danielspaniel/ember-data-factory-guy/issues/74)
-- Unloading records in teardown causes intermittent failure [\#73](https://github.com/danielspaniel/ember-data-factory-guy/issues/73)
-- Install is not working [\#72](https://github.com/danielspaniel/ember-data-factory-guy/issues/72)
-- resetModels when usingFixtureAdapter? [\#56](https://github.com/danielspaniel/ember-data-factory-guy/issues/56)
-
-## [v1.0.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.0.3) (2015-04-16)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.0.2...v1.0.3)
+## [v1.1.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.1.1) (2015-06-17)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.1.0...v1.1.1)
 
 **Implemented enhancements:**
 
-- blueprints for generating factories [\#70](https://github.com/danielspaniel/ember-data-factory-guy/issues/70)
-- merge ember-cli-data-factory-guy into this project and make this  "addon" capable [\#69](https://github.com/danielspaniel/ember-data-factory-guy/issues/69)
-- ES6 & Broccoli  [\#65](https://github.com/danielspaniel/ember-data-factory-guy/issues/65)
-
-## [v1.0.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.0.2) (2015-04-12)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.13...v1.0.2)
-
-## [v0.9.13](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.13) (2015-04-12)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v1.0.1...v0.9.13)
-
-## [v1.0.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v1.0.1) (2015-04-07)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.12...v1.0.1)
-
-## [v0.9.12](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.12) (2015-03-23)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.11...v0.9.12)
+- thinking about allowing factories to extend others  [\#93](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/93)
 
 **Closed issues:**
 
-- Manually set handleCreate response. [\#68](https://github.com/danielspaniel/ember-data-factory-guy/issues/68)
+- Error: Assertion Failed: FactoryGuy\#setStore needs a valid store instance.You passed in \[undefined\] [\#94](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/94)
+- Can't seem to use type as a property name [\#92](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/92)
 
-## [v0.9.11](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.11) (2015-03-19)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.10...v0.9.11)
+## [v1.1.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.1.0) (2015-06-15)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.0.12...v1.1.0)
+
+## [v1.0.12](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.0.12) (2015-06-11)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.0.11...v1.0.12)
 
 **Closed issues:**
 
-- define failing on merge [\#67](https://github.com/danielspaniel/ember-data-factory-guy/issues/67)
-- handleCreate seems to require an Em.run [\#62](https://github.com/danielspaniel/ember-data-factory-guy/issues/62)
-- Issue when using handleUpdate [\#60](https://github.com/danielspaniel/ember-data-factory-guy/issues/60)
+- Deprecation of `typeKey` in Ember Data [\#91](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/91)
+
+## [v1.0.11](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.0.11) (2015-06-11)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.0.10...v1.0.11)
+
+**Closed issues:**
+
+- Not possible to mock multiple `save\(\)` calls with handleCreate [\#88](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/88)
+- add .andFail\(\) option to handleFind\(\) [\#84](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/84)
 
 **Merged pull requests:**
 
-- Use  typeKey for relationship instead of attribute name for build fixture relationship [\#66](https://github.com/danielspaniel/ember-data-factory-guy/pull/66) ([cristinawithout](https://github.com/cristinawithout))
+- update store:main references to use store:application as store:main is now deprecated [\#90](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/90) ([jcope2013](https://github.com/jcope2013))
+- Mocking a failed reload typo fix [\#89](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/89) ([nummi](https://github.com/nummi))
 
-## [v0.9.10](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.10) (2015-02-23)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.9...v0.9.10)
+## [v1.0.10](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.0.10) (2015-06-02)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.0.9...v1.0.10)
 
 **Closed issues:**
 
-- Version 0.9.9 [\#64](https://github.com/danielspaniel/ember-data-factory-guy/issues/64)
+- upgrade ember-cli to 0.2.5 [\#86](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/86)
+
+## [v1.0.9](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.0.9) (2015-05-24)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.0.8...v1.0.9)
+
+**Closed issues:**
+
+- Install failure \(ember-cli 0.2.1\) [\#87](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/87)
 
 **Merged pull requests:**
 
-- \[WIP\] Handle update [\#63](https://github.com/danielspaniel/ember-data-factory-guy/pull/63) ([pedrokiefer](https://github.com/pedrokiefer))
+- \[WIP\] Add andFail\(\) method to handleFind\(\) [\#85](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/85) ([alexanderjeurissen](https://github.com/alexanderjeurissen))
 
-## [v0.9.9](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.9) (2015-02-18)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.8...v0.9.9)
+## [v1.0.8](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.0.8) (2015-05-08)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.0.7...v1.0.8)
 
 **Closed issues:**
 
-- Release incorporating `var` fix? [\#61](https://github.com/danielspaniel/ember-data-factory-guy/issues/61)
-
-## [v0.9.8](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.8) (2015-02-03)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.7...v0.9.8)
-
-## [v0.9.7](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.7) (2015-01-23)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.6...v0.9.7)
+- Passing match to handleCreate results in false positive [\#81](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/81)
+- FactoryGuy.hasMany fails with error `'undefined' is not an object \(evaluating 'traits\[trait\]'\)` [\#80](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/80)
 
 **Merged pull requests:**
 
-- Delete records created by MockCreateRequest [\#58](https://github.com/danielspaniel/ember-data-factory-guy/pull/58) ([mmelvin0](https://github.com/mmelvin0))
-- Allows custom mapping of objects. [\#55](https://github.com/danielspaniel/ember-data-factory-guy/pull/55) ([pedrokiefer](https://github.com/pedrokiefer))
+- ignore autogenerated .jscs files [\#83](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/83) ([GlennGeelen](https://github.com/GlennGeelen))
 
-## [v0.9.6](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.6) (2015-01-19)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.5...v0.9.6)
-
-**Closed issues:**
-
-- Match only set attributes [\#53](https://github.com/danielspaniel/ember-data-factory-guy/issues/53)
-
-## [v0.9.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.5) (2015-01-17)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.4...v0.9.5)
+## [v1.0.7](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.0.7) (2015-05-05)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.0.6...v1.0.7)
 
 **Closed issues:**
 
-- .reload\(\) [\#54](https://github.com/danielspaniel/ember-data-factory-guy/issues/54)
-- Ember Data version constraint [\#51](https://github.com/danielspaniel/ember-data-factory-guy/issues/51)
+- Dealing with multiple-inverse associations [\#57](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/57)
+
+## [v1.0.6](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.0.6) (2015-04-29)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.0.5...v1.0.6)
 
 **Merged pull requests:**
 
-- Add missing property for hasMany example [\#52](https://github.com/danielspaniel/ember-data-factory-guy/pull/52) ([mattmcginnis](https://github.com/mattmcginnis))
+- Get this add-on working when prototype extensions are disabled in Ember [\#78](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/78) ([chrisdpeters](https://github.com/chrisdpeters))
 
-## [v0.9.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.4) (2015-01-14)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.3...v0.9.4)
+## [v1.0.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.0.5) (2015-04-24)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.0.4...v1.0.5)
+
+**Closed issues:**
+
+- Multiple calls to handleCreate\(\) don't work [\#76](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/76)
 
 **Merged pull requests:**
 
-- Add handleFindOne method [\#50](https://github.com/danielspaniel/ember-data-factory-guy/pull/50) ([Marthyn](https://github.com/Marthyn))
-- Updating docs for DS.FixtureAdapter [\#49](https://github.com/danielspaniel/ember-data-factory-guy/pull/49) ([ksykulev](https://github.com/ksykulev))
+- Fixed typo in readme [\#77](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/77) ([kellyjensen](https://github.com/kellyjensen))
 
-## [v0.9.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.3) (2015-01-11)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.2...v0.9.3)
+## [v1.0.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.0.4) (2015-04-20)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.0.3...v1.0.4)
 
 **Closed issues:**
 
-- handleFindMany not correctly mocking requests? [\#46](https://github.com/danielspaniel/ember-data-factory-guy/issues/46)
+- Using store.find, unable to find fixtures for model type \(subclass of DS.Model\). If you're defining your fixtures using `Model.FIXTURES = ...`, please change it to `Model.reopenClass\({ FIXTURES: ... }\)`. [\#75](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/75)
+- Is not finding factories that are in tests/factories/ [\#74](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/74)
+- Unloading records in teardown causes intermittent failure [\#73](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/73)
+- Install is not working [\#72](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/72)
+- resetModels when usingFixtureAdapter? [\#56](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/56)
+
+## [v1.0.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.0.3) (2015-04-16)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.0.2...v1.0.3)
+
+**Implemented enhancements:**
+
+- blueprints for generating factories [\#70](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/70)
+- merge ember-cli-data-factory-guy into this project and make this  "addon" capable [\#69](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/69)
+- ES6 & Broccoli  [\#65](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/65)
+
+## [v1.0.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.0.2) (2015-04-12)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.13...v1.0.2)
+
+## [v0.9.13](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.13) (2015-04-12)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v1.0.1...v0.9.13)
+
+## [v1.0.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v1.0.1) (2015-04-07)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.12...v1.0.1)
+
+## [v0.9.12](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.12) (2015-03-23)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.11...v0.9.12)
+
+**Closed issues:**
+
+- Manually set handleCreate response. [\#68](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/68)
+
+## [v0.9.11](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.11) (2015-03-19)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.10...v0.9.11)
+
+**Closed issues:**
+
+- define failing on merge [\#67](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/67)
+- handleCreate seems to require an Em.run [\#62](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/62)
+- Issue when using handleUpdate [\#60](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/60)
 
 **Merged pull requests:**
 
-- Fixture Adapter Tests Pass [\#47](https://github.com/danielspaniel/ember-data-factory-guy/pull/47) ([ksykulev](https://github.com/ksykulev))
-- handleFindQuery json payload must be an array [\#45](https://github.com/danielspaniel/ember-data-factory-guy/pull/45) ([ksykulev](https://github.com/ksykulev))
+- Use  typeKey for relationship instead of attribute name for build fixture relationship [\#66](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/66) ([cristinawithout](https://github.com/cristinawithout))
 
-## [v0.9.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.2) (2014-12-23)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.1...v0.9.2)
-
-## [v0.9.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.1) (2014-12-16)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.9.0...v0.9.1)
+## [v0.9.10](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.10) (2015-02-23)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.9...v0.9.10)
 
 **Closed issues:**
 
-- support for custom data types [\#44](https://github.com/danielspaniel/ember-data-factory-guy/issues/44)
-
-## [v0.9.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.9.0) (2014-12-15)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.8.7...v0.9.0)
-
-**Closed issues:**
-
-- id not included in toJSON\(\) [\#42](https://github.com/danielspaniel/ember-data-factory-guy/issues/42)
+- Version 0.9.9 [\#64](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/64)
 
 **Merged pull requests:**
 
-- Add {includeId: true} to toJSON\(\) examples [\#43](https://github.com/danielspaniel/ember-data-factory-guy/pull/43) ([mattmcginnis](https://github.com/mattmcginnis))
+- \[WIP\] Handle update [\#63](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/63) ([pedrokiefer](https://github.com/pedrokiefer))
 
-## [v0.8.7](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.8.7) (2014-12-10)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.8.6...v0.8.7)
+## [v0.9.9](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.9) (2015-02-18)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.8...v0.9.9)
 
-## [v0.8.6](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.8.6) (2014-12-10)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.8.5...v0.8.6)
+**Closed issues:**
+
+- Release incorporating `var` fix? [\#61](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/61)
+
+## [v0.9.8](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.8) (2015-02-03)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.7...v0.9.8)
+
+## [v0.9.7](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.7) (2015-01-23)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.6...v0.9.7)
 
 **Merged pull requests:**
 
-- Support pushing embedded json into fixture adapter [\#48](https://github.com/danielspaniel/ember-data-factory-guy/pull/48) ([ksykulev](https://github.com/ksykulev))
-- Cleaning up pushFixture. [\#41](https://github.com/danielspaniel/ember-data-factory-guy/pull/41) ([ksykulev](https://github.com/ksykulev))
+- Delete records created by MockCreateRequest [\#58](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/58) ([mmelvin0](https://github.com/mmelvin0))
+- Allows custom mapping of objects. [\#55](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/55) ([pedrokiefer](https://github.com/pedrokiefer))
 
-## [v0.8.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.8.5) (2014-12-06)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.8.4...v0.8.5)
+## [v0.9.6](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.6) (2015-01-19)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.5...v0.9.6)
 
 **Closed issues:**
 
-- Improvement: expecting specific parameters [\#36](https://github.com/danielspaniel/ember-data-factory-guy/issues/36)
-- HandleUpdate builds the wrong url  [\#29](https://github.com/danielspaniel/ember-data-factory-guy/issues/29)
-- AMD/Require and use strict [\#21](https://github.com/danielspaniel/ember-data-factory-guy/issues/21)
+- Match only set attributes [\#53](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/53)
+
+## [v0.9.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.5) (2015-01-17)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.4...v0.9.5)
+
+**Closed issues:**
+
+- .reload\(\) [\#54](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/54)
+- Ember Data version constraint [\#51](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/51)
 
 **Merged pull requests:**
 
-- Fixtures inserted with equivalent ids get updated [\#40](https://github.com/danielspaniel/ember-data-factory-guy/pull/40) ([ksykulev](https://github.com/ksykulev))
-- Changing modelName to type [\#39](https://github.com/danielspaniel/ember-data-factory-guy/pull/39) ([ksykulev](https://github.com/ksykulev))
+- Add missing property for hasMany example [\#52](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/52) ([mattmcginnis](https://github.com/mattmcginnis))
 
-## [v0.8.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.8.4) (2014-12-04)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.8.3...v0.8.4)
-
-**Merged pull requests:**
-
-- Complete AMD module extraction \(tested with ember-cli\) [\#38](https://github.com/danielspaniel/ember-data-factory-guy/pull/38) ([indirect](https://github.com/indirect))
-
-## [v0.8.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.8.3) (2014-11-27)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.8.2...v0.8.3)
-
-## [v0.8.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.8.2) (2014-11-27)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.8.1...v0.8.2)
-
-**Closed issues:**
-
-- Improvement: Ember cli support [\#37](https://github.com/danielspaniel/ember-data-factory-guy/issues/37)
-
-## [v0.8.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.8.1) (2014-11-18)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.8.0...v0.8.1)
-
-## [v0.8.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.8.0) (2014-11-14)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.7.9...v0.8.0)
+## [v0.9.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.4) (2015-01-14)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.3...v0.9.4)
 
 **Merged pull requests:**
 
-- Convert the Bower dist file into a CommonJS and AMD compatible module [\#35](https://github.com/danielspaniel/ember-data-factory-guy/pull/35) ([indirect](https://github.com/indirect))
+- Add handleFindOne method [\#50](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/50) ([Marthyn](https://github.com/Marthyn))
+- Updating docs for DS.FixtureAdapter [\#49](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/49) ([ksykulev](https://github.com/ksykulev))
 
-## [v0.7.9](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.7.9) (2014-11-13)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.7.8...v0.7.9)
+## [v0.9.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.3) (2015-01-11)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.2...v0.9.3)
 
 **Closed issues:**
 
-- Hard dependencies on Ember 1.7.0 and jQuery 2.0.3 are awful [\#33](https://github.com/danielspaniel/ember-data-factory-guy/issues/33)
+- handleFindMany not correctly mocking requests? [\#46](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/46)
 
 **Merged pull requests:**
 
-- Make jshint happy [\#34](https://github.com/danielspaniel/ember-data-factory-guy/pull/34) ([indirect](https://github.com/indirect))
+- Fixture Adapter Tests Pass [\#47](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/47) ([ksykulev](https://github.com/ksykulev))
+- handleFindQuery json payload must be an array [\#45](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/45) ([ksykulev](https://github.com/ksykulev))
 
-## [v0.7.8](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.7.8) (2014-11-12)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.7.7...v0.7.8)
+## [v0.9.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.2) (2014-12-23)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.1...v0.9.2)
 
-**Closed issues:**
-
-- Does not use model-specific adapters for buildURL [\#31](https://github.com/danielspaniel/ember-data-factory-guy/issues/31)
-
-## [v0.7.7](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.7.7) (2014-11-09)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.7.6...v0.7.7)
+## [v0.9.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.1) (2014-12-16)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.9.0...v0.9.1)
 
 **Closed issues:**
 
-- Our lovely "'typeKey' of undefined" again [\#28](https://github.com/danielspaniel/ember-data-factory-guy/issues/28)
-- Integration tests bypassing store and making server requests. [\#27](https://github.com/danielspaniel/ember-data-factory-guy/issues/27)
+- support for custom data types [\#44](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/44)
+
+## [v0.9.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.9.0) (2014-12-15)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.8.7...v0.9.0)
+
+**Closed issues:**
+
+- id not included in toJSON\(\) [\#42](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/42)
 
 **Merged pull requests:**
 
-- Get the adapter for the model type if exists [\#32](https://github.com/danielspaniel/ember-data-factory-guy/pull/32) ([cristinawithout](https://github.com/cristinawithout))
+- Add {includeId: true} to toJSON\(\) examples [\#43](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/43) ([mattmcginnis](https://github.com/mattmcginnis))
 
-## [v0.7.6](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.7.6) (2014-11-01)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.7.5...v0.7.6)
+## [v0.8.7](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.8.7) (2014-12-10)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.8.6...v0.8.7)
 
-**Merged pull requests:**
-
-- adds $.mockjax.clear\(\) to the mixin's teardown method. [\#30](https://github.com/danielspaniel/ember-data-factory-guy/pull/30) ([yratanov](https://github.com/yratanov))
-
-## [v0.7.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.7.5) (2014-10-31)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.7.4...v0.7.5)
-
-## [v0.7.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.7.4) (2014-10-31)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.7.3...v0.7.4)
-
-**Closed issues:**
-
-- "typeKey of undefined" \#3 [\#26](https://github.com/danielspaniel/ember-data-factory-guy/issues/26)
-
-## [v0.7.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.7.3) (2014-10-27)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.7.2...v0.7.3)
-
-**Closed issues:**
-
-- 'typeKey' of undefined strikes back! [\#25](https://github.com/danielspaniel/ember-data-factory-guy/issues/25)
-- Cannot read property 'typeKey' of undefined [\#24](https://github.com/danielspaniel/ember-data-factory-guy/issues/24)
-
-## [v0.7.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.7.2) (2014-10-17)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.7.1.1...v0.7.2)
-
-## [v0.7.1.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.7.1.1) (2014-10-04)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.7.1...v0.7.1.1)
-
-## [v0.7.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.7.1) (2014-10-04)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.7.0...v0.7.1)
-
-## [v0.7.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.7.0) (2014-09-15)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.6.4...v0.7.0)
-
-## [v0.6.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.6.4) (2014-09-12)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.6.3...v0.6.4)
-
-## [v0.6.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.6.3) (2014-09-10)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.6.2...v0.6.3)
-
-**Closed issues:**
-
-- Can you create a release with this important commit? a8bb74c737879dcdae5274d76b62f54607f4c81f [\#20](https://github.com/danielspaniel/ember-data-factory-guy/issues/20)
-- Create blueprint factory file, when create model in ember-cli. [\#17](https://github.com/danielspaniel/ember-data-factory-guy/issues/17)
-
-## [v0.6.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.6.2) (2014-09-04)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.6.1...v0.6.2)
-
-**Closed issues:**
-
-- Write some articles about ember-data-factory-guy. [\#19](https://github.com/danielspaniel/ember-data-factory-guy/issues/19)
-- License file [\#18](https://github.com/danielspaniel/ember-data-factory-guy/issues/18)
-- Compound factory specification [\#12](https://github.com/danielspaniel/ember-data-factory-guy/issues/12)
+## [v0.8.6](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.8.6) (2014-12-10)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.8.5...v0.8.6)
 
 **Merged pull requests:**
 
-- Fix FixtureAdapter resolve of hasMany relationship on save [\#22](https://github.com/danielspaniel/ember-data-factory-guy/pull/22) ([KnownSubset](https://github.com/KnownSubset))
+- Support pushing embedded json into fixture adapter [\#48](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/48) ([ksykulev](https://github.com/ksykulev))
+- Cleaning up pushFixture. [\#41](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/41) ([ksykulev](https://github.com/ksykulev))
 
-## [v0.6.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.6.1) (2014-08-21)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.6.0...v0.6.1)
-
-## [v0.6.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.6.0) (2014-08-19)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.5.3...v0.6.0)
+## [v0.8.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.8.5) (2014-12-06)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.8.4...v0.8.5)
 
 **Closed issues:**
 
-- Any way to configure a api namespace for FactoryGuyTestMixin? [\#16](https://github.com/danielspaniel/ember-data-factory-guy/issues/16)
-- Use with Ember CLI [\#10](https://github.com/danielspaniel/ember-data-factory-guy/issues/10)
+- Improvement: expecting specific parameters [\#36](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/36)
+- HandleUpdate builds the wrong url  [\#29](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/29)
+- AMD/Require and use strict [\#21](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/21)
 
-## [v0.5.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.5.3) (2014-08-19)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.5.2...v0.5.3)
+**Merged pull requests:**
+
+- Fixtures inserted with equivalent ids get updated [\#40](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/40) ([ksykulev](https://github.com/ksykulev))
+- Changing modelName to type [\#39](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/39) ([ksykulev](https://github.com/ksykulev))
+
+## [v0.8.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.8.4) (2014-12-04)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.8.3...v0.8.4)
+
+**Merged pull requests:**
+
+- Complete AMD module extraction \(tested with ember-cli\) [\#38](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/38) ([indirect](https://github.com/indirect))
+
+## [v0.8.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.8.3) (2014-11-27)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.8.2...v0.8.3)
+
+## [v0.8.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.8.2) (2014-11-27)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.8.1...v0.8.2)
 
 **Closed issues:**
 
-- fix versioning [\#15](https://github.com/danielspaniel/ember-data-factory-guy/issues/15)
-- hasMany associations [\#14](https://github.com/danielspaniel/ember-data-factory-guy/issues/14)
+- Improvement: Ember cli support [\#37](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/37)
 
-## [v0.5.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.5.2) (2014-08-02)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.5.1...v0.5.2)
+## [v0.8.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.8.1) (2014-11-18)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.8.0...v0.8.1)
 
-## [v0.5.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.5.1) (2014-08-01)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.5.0...v0.5.1)
-
-**Merged pull requests:**
-
-- Fixed createRecord for one-to-none associations [\#13](https://github.com/danielspaniel/ember-data-factory-guy/pull/13) ([KnownSubset](https://github.com/KnownSubset))
-
-## [v0.5.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.5.0) (2014-08-01)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.4.2...v0.5.0)
-
-## [v0.4.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.4.2) (2014-07-16)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.4.1...v0.4.2)
+## [v0.8.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.8.0) (2014-11-14)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.7.9...v0.8.0)
 
 **Merged pull requests:**
 
-- Added support for async relationships [\#9](https://github.com/danielspaniel/ember-data-factory-guy/pull/9) ([KnownSubset](https://github.com/KnownSubset))
+- Convert the Bower dist file into a CommonJS and AMD compatible module [\#35](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/35) ([indirect](https://github.com/indirect))
 
-## [v0.4.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.4.1) (2014-07-11)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.3.10...v0.4.1)
-
-## [v0.3.10](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.3.10) (2014-06-12)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.3.9...v0.3.10)
-
-## [v0.3.9](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.3.9) (2014-06-05)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.3.8...v0.3.9)
+## [v0.7.9](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.7.9) (2014-11-13)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.7.8...v0.7.9)
 
 **Closed issues:**
 
-- Syntax to define sequences [\#7](https://github.com/danielspaniel/ember-data-factory-guy/issues/7)
-
-## [v0.3.8](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.3.8) (2014-06-03)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.3.7...v0.3.8)
-
-## [v0.3.7](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.3.7) (2014-06-02)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.3.6...v0.3.7)
-
-## [v0.3.6](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.3.6) (2014-05-30)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.3.5...v0.3.6)
-
-## [v0.3.5](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.3.5) (2014-05-29)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.3.4...v0.3.5)
-
-## [v0.3.4](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.3.4) (2014-05-24)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.3.3...v0.3.4)
-
-## [v0.3.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.3.3) (2014-05-24)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.3.2...v0.3.3)
-
-## [v0.3.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.3.2) (2014-05-24)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.3.1...v0.3.2)
-
-## [v0.3.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.3.1) (2014-05-23)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.3.0...v0.3.1)
-
-## [v0.3.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.3.0) (2014-05-23)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.2.1...v0.3.0)
+- Hard dependencies on Ember 1.7.0 and jQuery 2.0.3 are awful [\#33](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/33)
 
 **Merged pull requests:**
 
-- Fix some typos in the docs. [\#4](https://github.com/danielspaniel/ember-data-factory-guy/pull/4) ([cibernox](https://github.com/cibernox))
+- Make jshint happy [\#34](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/34) ([indirect](https://github.com/indirect))
 
-## [v0.2.1](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.2.1) (2014-05-10)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.2.0...v0.2.1)
-
-## [v0.2.0](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.2.0) (2014-05-08)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.1.3...v0.2.0)
-
-## [v0.1.3](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.1.3) (2014-05-06)
-[Full Changelog](https://github.com/danielspaniel/ember-data-factory-guy/compare/v0.1.2...v0.1.3)
+## [v0.7.8](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.7.8) (2014-11-12)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.7.7...v0.7.8)
 
 **Closed issues:**
 
-- Avoid using store? [\#3](https://github.com/danielspaniel/ember-data-factory-guy/issues/3)
-- Sequences [\#2](https://github.com/danielspaniel/ember-data-factory-guy/issues/2)
+- Does not use model-specific adapters for buildURL [\#31](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/31)
 
-## [v0.1.2](https://github.com/danielspaniel/ember-data-factory-guy/tree/v0.1.2) (2014-05-06)
+## [v0.7.7](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.7.7) (2014-11-09)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.7.6...v0.7.7)
+
+**Closed issues:**
+
+- Our lovely "'typeKey' of undefined" again [\#28](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/28)
+- Integration tests bypassing store and making server requests. [\#27](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/27)
+
 **Merged pull requests:**
 
-- fix for check property [\#1](https://github.com/danielspaniel/ember-data-factory-guy/pull/1) ([OpakAlex](https://github.com/OpakAlex))
+- Get the adapter for the model type if exists [\#32](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/32) ([cristinawithout](https://github.com/cristinawithout))
+
+## [v0.7.6](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.7.6) (2014-11-01)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.7.5...v0.7.6)
+
+**Merged pull requests:**
+
+- adds $.mockjax.clear\(\) to the mixin's teardown method. [\#30](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/30) ([yratanov](https://github.com/yratanov))
+
+## [v0.7.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.7.5) (2014-10-31)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.7.4...v0.7.5)
+
+## [v0.7.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.7.4) (2014-10-31)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.7.3...v0.7.4)
+
+**Closed issues:**
+
+- "typeKey of undefined" \#3 [\#26](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/26)
+
+## [v0.7.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.7.3) (2014-10-27)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.7.2...v0.7.3)
+
+**Closed issues:**
+
+- 'typeKey' of undefined strikes back! [\#25](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/25)
+- Cannot read property 'typeKey' of undefined [\#24](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/24)
+
+## [v0.7.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.7.2) (2014-10-17)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.7.1.1...v0.7.2)
+
+## [v0.7.1.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.7.1.1) (2014-10-04)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.7.1...v0.7.1.1)
+
+## [v0.7.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.7.1) (2014-10-04)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.7.0...v0.7.1)
+
+## [v0.7.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.7.0) (2014-09-15)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.6.4...v0.7.0)
+
+## [v0.6.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.6.4) (2014-09-12)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.6.3...v0.6.4)
+
+## [v0.6.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.6.3) (2014-09-10)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.6.2...v0.6.3)
+
+**Closed issues:**
+
+- Can you create a release with this important commit? a8bb74c737879dcdae5274d76b62f54607f4c81f [\#20](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/20)
+- Create blueprint factory file, when create model in ember-cli. [\#17](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/17)
+
+## [v0.6.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.6.2) (2014-09-04)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.6.1...v0.6.2)
+
+**Closed issues:**
+
+- Write some articles about ember-data-factory-guy. [\#19](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/19)
+- License file [\#18](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/18)
+- Compound factory specification [\#12](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/12)
+
+**Merged pull requests:**
+
+- Fix FixtureAdapter resolve of hasMany relationship on save [\#22](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/22) ([KnownSubset](https://github.com/KnownSubset))
+
+## [v0.6.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.6.1) (2014-08-21)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.6.0...v0.6.1)
+
+## [v0.6.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.6.0) (2014-08-19)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.5.3...v0.6.0)
+
+**Closed issues:**
+
+- Any way to configure a api namespace for FactoryGuyTestMixin? [\#16](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/16)
+- Use with Ember CLI [\#10](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/10)
+
+## [v0.5.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.5.3) (2014-08-19)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.5.2...v0.5.3)
+
+**Closed issues:**
+
+- fix versioning [\#15](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/15)
+- hasMany associations [\#14](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/14)
+
+## [v0.5.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.5.2) (2014-08-02)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.5.1...v0.5.2)
+
+## [v0.5.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.5.1) (2014-08-01)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.5.0...v0.5.1)
+
+**Merged pull requests:**
+
+- Fixed createRecord for one-to-none associations [\#13](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/13) ([KnownSubset](https://github.com/KnownSubset))
+
+## [v0.5.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.5.0) (2014-08-01)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.4.2...v0.5.0)
+
+## [v0.4.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.4.2) (2014-07-16)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.4.1...v0.4.2)
+
+**Merged pull requests:**
+
+- Added support for async relationships [\#9](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/9) ([KnownSubset](https://github.com/KnownSubset))
+
+## [v0.4.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.4.1) (2014-07-11)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.3.10...v0.4.1)
+
+## [v0.3.10](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.3.10) (2014-06-12)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.3.9...v0.3.10)
+
+## [v0.3.9](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.3.9) (2014-06-05)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.3.8...v0.3.9)
+
+**Closed issues:**
+
+- Syntax to define sequences [\#7](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/7)
+
+## [v0.3.8](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.3.8) (2014-06-03)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.3.7...v0.3.8)
+
+## [v0.3.7](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.3.7) (2014-06-02)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.3.6...v0.3.7)
+
+## [v0.3.6](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.3.6) (2014-05-30)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.3.5...v0.3.6)
+
+## [v0.3.5](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.3.5) (2014-05-29)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.3.4...v0.3.5)
+
+## [v0.3.4](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.3.4) (2014-05-24)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.3.3...v0.3.4)
+
+## [v0.3.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.3.3) (2014-05-24)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.3.2...v0.3.3)
+
+## [v0.3.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.3.2) (2014-05-24)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.3.1...v0.3.2)
+
+## [v0.3.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.3.1) (2014-05-23)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.3.0...v0.3.1)
+
+## [v0.3.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.3.0) (2014-05-23)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.2.1...v0.3.0)
+
+**Merged pull requests:**
+
+- Fix some typos in the docs. [\#4](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/4) ([cibernox](https://github.com/cibernox))
+
+## [v0.2.1](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.2.1) (2014-05-10)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.2.0...v0.2.1)
+
+## [v0.2.0](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.2.0) (2014-05-08)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.1.3...v0.2.0)
+
+## [v0.1.3](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.1.3) (2014-05-06)
+[Full Changelog](https://github.com/adopted-ember-addons/ember-data-factory-guy/compare/v0.1.2...v0.1.3)
+
+**Closed issues:**
+
+- Avoid using store? [\#3](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/3)
+- Sequences [\#2](https://github.com/adopted-ember-addons/ember-data-factory-guy/issues/2)
+
+## [v0.1.2](https://github.com/adopted-ember-addons/ember-data-factory-guy/tree/v0.1.2) (2014-05-06)
+**Merged pull requests:**
+
+- fix for check property [\#1](https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/1) ([OpakAlex](https://github.com/OpakAlex))
 
 
 

--- a/README.md
+++ b/README.md
@@ -2115,8 +2115,9 @@ describe('Admin View', function() {
 ```
 
 ### Releasing new versions
-1. ?
-2. ?
+1. npm version (patch|minor|major)
+2. npm publish
+3. git push --tags
 
 ### ChangeLog
   - [Release Notes](/releases)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Factories simplify the process of testing, making you more efficient and your te
 **NEW** starting with v3.8
   - jquery is no longer required and fetch adapter is used with ember-data
   - you can still use jquery if you want to  
-  - if you are addon author using factory guy set up your application adapter like [this](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/dummy/app/adapters/application.js)
+  - if you are addon author using factory guy set up your application adapter like [this](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/dummy/app/adapters/application.js)
   
 **NEW** starting with v3.2.1
   - You can setup data AND links for your async relationship [Check it out](#special-tips-for-links)
@@ -16,7 +16,7 @@ Factories simplify the process of testing, making you more efficient and your te
 **NEW** You can use factory guy in ember-twiddle
   - Using [Scenarios](https://ember-twiddle.com/421f16ecc55b5d35783c243b8d99f2be?openFiles=tests.unit.model.user-test.js%2C)
 
-**NEW** If using new style of ember-qunit acceptance tests with ```setupApplicationTest``` check out demo here: [user-view-test.js:](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/acceptance/user-view-test.js)
+**NEW** If using new style of ember-qunit acceptance tests with ```setupApplicationTest``` check out demo here: [user-view-test.js:](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/acceptance/user-view-test.js)
 
 **NEW** starting with v2.13.27
   - get attributes for factory defined models with ```attributesFor```
@@ -120,7 +120,7 @@ In the following examples, assume the models look like this:
 
 #### Standard models
 
-- Sample full blown factory: [`user.js`](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/dummy/app/tests/factories/user.js)
+- Sample full blown factory: [`user.js`](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/dummy/app/tests/factories/user.js)
 
 - Brief sample of a factory definition:
 ```javascript
@@ -543,7 +543,7 @@ the reverse 'user' belongsTo association is being setup for you on the project
     will take precedence over an inherited one. So you can override some
     attributes in the default section ( for example ), and inherit the rest
 
-There is a sample Factory using inheritance here: [`big-group.js`](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/dummy/app/tests/factories/big-group.js)
+There is a sample Factory using inheritance here: [`big-group.js`](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/dummy/app/tests/factories/big-group.js)
 
 
 ### Transient Attributes
@@ -732,7 +732,7 @@ Remember to import the `run` function with `import { run } from "@ember/runloop"
     - except that the model will be a newly created record with no id
 
 ##### `FactoryGuy.makeList`
-  - check out [(user factory):](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/dummy/app/tests/factories/user.js) to see 'bob' user and 'with_car' trait
+  - check out [(user factory):](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/dummy/app/tests/factories/user.js) to see 'bob' user and 'with_car' trait
 
 Usage:
 
@@ -936,7 +936,7 @@ Usage:
     - `get(index)` gives you the info for a hasMany relationship at that index
     - `get(relationships)` gives you just the id or type ( if polymorphic )
       - better to compose the build relationships by hand if you need more info
-  - check out [user factory:](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/dummy/app/tests/factories/user.js) to see 'boblike' and 'adminlike' user traits
+  - check out [user factory:](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/dummy/app/tests/factories/user.js) to see 'boblike' and 'adminlike' user traits
 
 ```javascript
   let json = build('user');
@@ -1132,8 +1132,8 @@ let employee = build('employee', { phoneNumbers }).get();
 ```
 
 For a more detailed example of setting up fragments have a look at:
-  - model test [employee test](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/unit/models/employee-test.js).
-  - acceptance test [employee-view-test](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/acceptance/employee-view-test.js).
+  - model test [employee test](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/unit/models/employee-test.js).
+  - acceptance test [employee-view-test](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/acceptance/employee-view-test.js).
 
 ### Creating Factories in Addons
 If you are making an addon with factories and you want the factories available to Ember apps using your addon, place the factories in `test-support/factories` instead of `tests/factories`. They should be available both within your addon and in Ember apps that use your addon.
@@ -1234,11 +1234,11 @@ test("Using FactoryGuy.cacheOnlyMode with except", async function() {
       });
     });
     ```
-- Sample model test: [profile-test.js](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/unit/models/profile-test.js)
+- Sample model test: [profile-test.js](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/unit/models/profile-test.js)
   - Use `moduleForModel` ( ember-qunit ), or `describeModel` ( ember-mocha ) test helper
   - manually set up FactoryGuy
 
-- Sample component test: [single-user-test.js](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/components/single-user-test.js)
+- Sample component test: [single-user-test.js](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/components/single-user-test.js)
   - Using `moduleForComponent` ( ember-qunit ), or `describeComponent` ( ember-mocha ) helper
   - manually sets up FactoryGuy
 
@@ -1268,7 +1268,7 @@ test("Using FactoryGuy.cacheOnlyMode with except", async function() {
 
 ### Acceptance Tests
 
-- For using new style of ember-qunit with ```setupApplicationTest``` check out demo here: [user-view-test.js:](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/acceptance/user-view-test.js)
+- For using new style of ember-qunit with ```setupApplicationTest``` check out demo here: [user-view-test.js:](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/acceptance/user-view-test.js)
 
 ##### Using mock methods
 
@@ -1364,7 +1364,7 @@ The `isDestroyed` property is set to `true` when the mock is destroyed.
   - Takes modifier method `returns()` for controlling the response payload
     - returns( model / json / id )
   - Takes modifier method `adapterOptions()` for setting adapterOptions ( get passed to urlForFindRecord )
-  - Sample acceptance tests using `mockFindRecord`: [user-view-test.js:](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/acceptance/user-view-test.js)
+  - Sample acceptance tests using `mockFindRecord`: [user-view-test.js:](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/acceptance/user-view-test.js)
 
 Usage:
 ```javascript
@@ -1444,7 +1444,7 @@ Usage:
     - returns( models / json / ids )
   - Takes modifier method `adapterOptions()` for setting adapterOptions ( get passed to urlForFindAll )
     - used just as in mockFindRecord ( see example there )
-  - Sample acceptance tests using `mockFindAll`: [users-view-test.js](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/acceptance/users-view-test.js)
+  - Sample acceptance tests using `mockFindAll`: [users-view-test.js](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/acceptance/users-view-test.js)
 
 Usage:
 
@@ -1530,7 +1530,7 @@ Usage:
    - Takes modifier methods for matching the query params
     - `withParams( object )`
     - `withSomeParams( object )`
-  - Sample acceptance tests using `mockQuery`: [user-search-test.js](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/acceptance/user-search-test.js)
+  - Sample acceptance tests using `mockQuery`: [user-search-test.js](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/acceptance/user-search-test.js)
 
 Usage:
 
@@ -2074,10 +2074,10 @@ describe('Admin View', function() {
 #### Tip 4: Testing mocks ( async testing ) in unit tests
 
  - Two ways to handle asyncronous test
-   - async / await ( most elegant ) [Sample test](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/unit/models/user-test.js#L44)
+   - async / await ( most elegant ) [Sample test](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/unit/models/user-test.js#L44)
       - need to declare polyfill for ember-cli-babel options
-       in [ember-cli-build](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/ember-cli-build.js#L7)
-   - using `assert.async()` (qunit) / `done` (mocha) [Sample test](https://github.com/danielspaniel/ember-data-factory-guy/blob/master/tests/unit/models/user-test.js#L53)
+       in [ember-cli-build](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/ember-cli-build.js#L7)
+   - using `assert.async()` (qunit) / `done` (mocha) [Sample test](https://github.com/adopted-ember-addons/ember-data-factory-guy/blob/master/tests/unit/models/user-test.js#L53)
 
 #### Tip 5: Testing model's custom `serialize()` method
   - The fact that you can match on attributes in `mockUpdate` and `mockCreate` means

--- a/README.md
+++ b/README.md
@@ -2114,6 +2114,9 @@ describe('Admin View', function() {
   assert.equal(json.name, 'Daniel-san');
 ```
 
+### Releasing new versions
+1. ?
+2. ?
 
 ### ChangeLog
   - [Release Notes](/releases)

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "author": "Daniel Sudol <dansudol@yahoo.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/danielspaniel/ember-data-factory-guy"
+    "url": "https://github.com/adopted-ember-addons/ember-data-factory-guy"
   },
-  "homepage": "https://github.com/danielspaniel/ember-data-factory-guy",
+  "homepage": "https://github.com/adopted-ember-addons/ember-data-factory-guy",
   "scripts": {
     "start": "ember server",
     "build": "ember build",


### PR DESCRIPTION
Part of https://github.com/danielspaniel/ember-data-factory-guy/issues/419

Starts the process of changing repo ownership over to the adopted-ember-addons org.

* Changes all references of www.github.com/danielspaniel to www.github.com/adopted-ember-addons
* Documents the release process. (I know adopted-ember-addons has an official process based on using release-it but I don't think we need to figure that out right now to change ownership)

