### PR TITLE
update release-plan workflows

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -1,5 +1,6 @@
-name: Release Plan Review
+name: Plan Release
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -14,74 +15,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-plan:
-    name: 'Check Release Plan'
+  should-run-release-plan-prepare:
+    name: Should we run release-plan prepare?
     runs-on: ubuntu-latest
     outputs:
-      command: ${{ steps.check-release.outputs.command }}
-
+      should-prepare: ${{ steps.should-prepare.outputs.should-prepare }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: release-plan/actions/should-prepare-release@v1
         with:
-          fetch-depth: 0
           ref: 'master'
-      # This will only cause the `check-plan` job to have a "command" of `release`
-      # when the .release-plan.json file was changed on the last commit.
-      - id: check-release
-        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
+        id: should-prepare
 
-  prepare_release_notes:
-    name: Prepare Release Notes
+  create-prepare-release-pr:
+    name: Create Prepare Release PR
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: check-plan
+    needs: should-run-release-plan-prepare
     permissions:
       contents: write
       issues: read
       pull-requests: write
-    outputs:
-      explanation: ${{ steps.explanation.outputs.text }}
-    # only run on push event if plan wasn't updated (don't create a release plan when we're releasing)
-    # only run on labeled event if the PR has already been merged
-    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
-
+    if: needs.should-run-release-plan-prepare.outputs.should-prepare == 'true'
     steps:
-      - uses: actions/checkout@v6
-        # We need to download lots of history so that
-        # github-changelog can discover what's changed since the last release
+      - uses: release-plan/actions/prepare@v1
+        name: Run release-plan prepare
         with:
-          fetch-depth: 0
           ref: 'master'
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-      - uses: pnpm/action-setup@v6
-      - run: pnpm install --frozen-lockfile
-      - name: 'Generate Explanation and Prep Changelogs'
-        id: explanation
-        run: |
-          set +e
-          pnpm release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)
-
-          if [ $? -ne 0 ]; then
-            echo 'text<<EOF' >> $GITHUB_OUTPUT
-            cat release-plan-stderr.txt >> $GITHUB_OUTPUT
-            echo 'EOF' >> $GITHUB_OUTPUT
-          else
-            echo 'text<<EOF' >> $GITHUB_OUTPUT
-            jq .description .release-plan.json -r >> $GITHUB_OUTPUT
-            echo 'EOF' >> $GITHUB_OUTPUT
-            rm release-plan-stderr.txt
-          fi
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+        id: explanation
 
       - uses: peter-evans/create-pull-request@v8
+        name: Create Prepare Release PR
         with:
-          commit-message: "Prepare Release using 'release-plan'"
+          commit-message: "Prepare Release ${{ steps.explanation.outputs.new-version}} using 'release-plan'"
           labels: 'internal'
+          sign-commits: true
           branch: release-preview
-          title: Prepare Release
+          title: Prepare Release ${{ steps.explanation.outputs.new-version }}
           body: |
             This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,5 @@
-# For every push to the master branch, this checks if the release-plan was
-# updated and if it was it will publish stable npm packages based on the
-# release plan
+# For every push to the primary branch with .release-plan.json modified,
+# runs release-plan.
 
 name: Publish Stable
 
@@ -10,49 +9,32 @@ on:
     branches:
       - main
       - master
+    paths:
+      - '.release-plan.json'
 
 concurrency:
   group: publish-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  check-plan:
-    name: 'Check Release Plan'
-    runs-on: ubuntu-latest
-    outputs:
-      command: ${{ steps.check-release.outputs.command }}
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          ref: 'master'
-      # This will only cause the `check-plan` job to have a result of `success`
-      # when the .release-plan.json file was changed on the last commit. This
-      # plus the fact that this action only runs on main will be enough of a guard
-      - id: check-release
-        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
-
   publish:
     name: 'NPM Publish'
     runs-on: ubuntu-latest
-    needs: check-plan
-    if: needs.check-plan.outputs.command == 'release'
     permissions:
       contents: write
-      pull-requests: write
+      id-token: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
           registry-url: 'https://registry.npmjs.org'
-      - uses: pnpm/action-setup@v6
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: npm publish
-        run: pnpm release-plan publish
+      - name: Publish to NPM
+        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Hey 👋  I noticed in https://github.com/adopted-ember-addons/ember-data-factory-guy/pull/561 that you updated one of the workflows and I saw that you weren't on the latest iteration of the release-plan stuff

I tend to update the release-plan workflows using `pnpm create release-plan-setup@latest` to make sure that I am on the latest (we put a lot of work into those templates to make sure people get the best experience)

This PR is just the output of that command 👍 